### PR TITLE
Phase 0: modular CMS foundation (cms-contracts, cms-core, cms-hello)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,57 @@
+name: Quality Gates
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, pdo, pdo_sqlite, bcmath, opcache, zip, gd, intl, pcntl, posix
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      # --- Style: Phase 0 code must be Pint-clean (existing app/ debt tracked separately) ---
+      - name: Pint (code style)
+        run: vendor/bin/pint --test packages/liberu-cms tests/Feature/Cms tests/Unit/Cms
+
+      # --- Static analysis: PHPStan at max level on every CMS package ---
+      - name: PHPStan (max level)
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=512M
+
+      # --- Refactoring safety: Rector must report no pending changes ---
+      - name: Rector (dry run)
+        run: vendor/bin/rector process packages/liberu-cms --dry-run --no-progress-bar
+
+      # --- Architecture: dependency direction + disable-any-module removability ---
+      - name: Architecture & removability guards
+        run: php artisan test tests/Feature/Cms/ArchitectureTest.php tests/Feature/Cms/RemovabilityTest.php tests/Feature/Cms/EmbeddabilityTest.php
+
+      # --- Mutation testing on the CMS kernel's business logic ---
+      # Non-blocking until the MSI thresholds are calibrated against real runs.
+      - name: Infection (mutation testing)
+        continue-on-error: true
+        run: vendor/bin/infection --no-progress --threads=max --ignore-msi-with-no-mutations

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Fortify;
 
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
@@ -26,10 +27,16 @@ class CreateNewUser implements CreatesNewUsers
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
-        return User::create([
-            'name' => $input['name'],
-            'email' => $input['email'],
-            'password' => Hash::make($input['password']),
-        ]);
+        return DB::transaction(function () use ($input): User {
+            $user = User::create([
+                'name' => $input['name'],
+                'email' => $input['email'],
+                'password' => Hash::make($input['password']),
+            ]);
+
+            $user->createPersonalTeam();
+
+            return $user;
+        });
     }
 }

--- a/app/Actions/Socialstream/CreateUserFromProvider.php
+++ b/app/Actions/Socialstream/CreateUserFromProvider.php
@@ -35,6 +35,7 @@ class CreateUserFromProvider implements CreatesUserFromProvider
                 'email' => $providerUser->getEmail(),
             ]), function (User $user) use ($provider, $providerUser) {
                 $user->markEmailAsVerified();
+                $user->createPersonalTeam();
 
                 if (Socialstream::hasProviderAvatarsFeature() && $providerUser->getAvatar()) {
                     $user->setProfilePhotoFromUrl($providerUser->getAvatar());

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -7,6 +7,7 @@ use App\Filament\Resources\MenuResource;
 use App\Http\Middleware\SetPermissionsTeam;
 use App\Models\Menu;
 use App\Models\MenuItem;
+use App\Models\Team;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Http\Middleware\Authenticate;
@@ -31,6 +32,10 @@ class AppPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
+        if (config('permission.teams')) {
+            $panel->tenant(Team::class, ownershipRelationship: 'team');
+        }
+
         return $panel
             ->default()
             ->id('app')

--- a/app/Traits/HasTeams.php
+++ b/app/Traits/HasTeams.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use App\Models\Membership;
+use App\Models\Role;
 use App\Models\Team;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Model;
@@ -10,9 +11,43 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 trait HasTeams
 {
+    /**
+     * Create a personal team for the user and make it their current tenant.
+     *
+     * Registration creates a user before it is authenticated, so the Team
+     * model's created hook cannot attach them; this does it explicitly and
+     * assigns the team's super_admin role within that team's permission scope.
+     */
+    public function createPersonalTeam(): Team
+    {
+        /** @var Team $team */
+        $team = $this->ownedTeams()->create([
+            'name' => Str::of($this->name)->explode(' ')->first().'\'s Team',
+            'personal_team' => true,
+        ]);
+
+        $this->forceFill(['current_team_id' => $team->id])->save();
+        $this->teams()->syncWithoutDetaching([$team->id]);
+
+        $superAdmin = Role::query()
+            ->where('name', 'super_admin')
+            ->where('team_id', $team->id)
+            ->first();
+
+        if ($superAdmin !== null) {
+            $previousTeamId = getPermissionsTeamId();
+            setPermissionsTeamId($team->id);
+            $this->assignRole($superAdmin);
+            setPermissionsTeamId($previousTeamId);
+        }
+
+        return $team;
+    }
+
     public function isCurrentTeam(Team $team): bool
     {
         return $team->id === $this->currentTeam->id;

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,12 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
-        "php": "^8.5",
         "bezhansalleh/filament-shield": "^4.0",
         "biostate/filament-menu-builder": "^5.0",
         "bursteri/socialstream": "^7.0",
@@ -20,13 +22,19 @@
         "laravel/reverb": "^1.10",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "liberu-cms/cms-hello": "*",
         "livewire/livewire": "^4.0",
+        "php": "^8.5",
         "spatie/laravel-passkeys": "^1.0",
         "spatie/laravel-permission": "^7.0",
         "stephenjude/filament-two-factor-authentication": "^5.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "infection/infection": "^0.34.0",
+        "larastan/larastan": "^3.10",
         "laravel/boost": "^2.0",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
@@ -35,6 +43,7 @@
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "5.x-dev",
         "pestphp/pest-plugin-laravel": "5.x-dev",
+        "phpstan/phpstan": "^2.2",
         "rector/rector": "^2.4"
     },
     "autoload": {
@@ -87,6 +96,15 @@
             "Illuminate\\Foundation\\ComposerScripts::prePackageUninstall"
         ]
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "packages/liberu-cms/*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
     "extra": {
         "laravel": {
             "dont-discover": []
@@ -96,9 +114,13 @@
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        },
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "infection/extension-installer": true
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acdd54cb93f307e8cc655b1ad089d73f",
+    "content-hash": "765c131cd66e6624b74ab6b892864934",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -470,23 +470,22 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.8",
+            "version": "0.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2"
             },
             "require-dev": {
-                "php-coveralls/php-coveralls": "^2.2",
                 "phpstan/phpstan": "2.1.22",
                 "phpunit/phpunit": "^11.5"
             },
@@ -518,7 +517,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.8"
+                "source": "https://github.com/brick/math/tree/0.17.2"
             },
             "funding": [
                 {
@@ -526,7 +525,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-10T14:33:43+00:00"
+            "time": "2026-05-25T20:34:43+00:00"
         },
         {
             "name": "bursteri/socialstream",
@@ -977,16 +976,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.12",
+            "version": "1.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
+                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
-                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/c008272789979f709f7fcb32c2ecf1d2db5e84e5",
+                "reference": "c008272789979f709f7fcb32c2ecf1d2db5e84e5",
                 "shasum": ""
             },
             "require": {
@@ -1033,7 +1032,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.13"
             },
             "funding": [
                 {
@@ -1045,7 +1044,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T11:26:22+00:00"
+            "time": "2026-07-18T12:35:13+00:00"
         },
         {
             "name": "composer/class-map-generator",
@@ -1118,16 +1117,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.10.0",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "c13824d95608b15913a7c0def0a3dea4474b71fc"
+                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/c13824d95608b15913a7c0def0a3dea4474b71fc",
-                "reference": "c13824d95608b15913a7c0def0a3dea4474b71fc",
+                "url": "https://api.github.com/repos/composer/composer/zipball/8d4439f572a97670a9edc039eb3b093cc976b4bc",
+                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc",
                 "shasum": ""
             },
             "require": {
@@ -1215,7 +1214,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.10.0"
+                "source": "https://github.com/composer/composer/tree/2.10.2"
             },
             "funding": [
                 {
@@ -1227,20 +1226,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T09:22:08+00:00"
+            "time": "2026-07-01T09:24:45+00:00"
         },
         {
             "name": "composer/metadata-minifier",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/metadata-minifier.git",
-                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+                "reference": "8e86142e3ade750b837d55e55f0cdc786d8da006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
-                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/8e86142e3ade750b837d55e55f0cdc786d8da006",
+                "reference": "8e86142e3ade750b837d55e55f0cdc786d8da006",
                 "shasum": ""
             },
             "require": {
@@ -1248,8 +1247,8 @@
             },
             "require-dev": {
                 "composer/composer": "^2",
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1",
+                "symfony/phpunit-bridge": "^4.2 || ^5 || ^6 || ^7"
             },
             "type": "library",
             "extra": {
@@ -1280,7 +1279,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/metadata-minifier/issues",
-                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.1"
             },
             "funding": [
                 {
@@ -1290,38 +1289,35 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2021-04-07T13:37:33+00:00"
+            "time": "2026-06-30T11:34:59+00:00"
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -1359,7 +1355,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -1369,13 +1365,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -2948,26 +2940,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -2975,8 +2967,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.4",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -3056,7 +3048,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -3072,20 +3064,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:40:51+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -3140,7 +3132,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -3156,20 +3148,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -3178,7 +3170,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -3259,7 +3251,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -3275,25 +3267,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.6",
+            "version": "v1.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
+                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/f6c24c21f42b990e9a58912b332d0874df6ba839",
+                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -3345,7 +3337,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.10"
             },
             "funding": [
                 {
@@ -3361,7 +3353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T22:00:21+00:00"
+            "time": "2026-07-17T13:53:03+00:00"
         },
         {
             "name": "internachi/modular",
@@ -3485,16 +3477,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.8.2",
+            "version": "6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
+                "reference": "8b1308a9d7bdbdb20ce87ef920f82b4564bb2d33",
                 "shasum": ""
             },
             "require": {
@@ -3554,9 +3546,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.10.0"
             },
-            "time": "2026-05-05T05:39:01+00:00"
+            "time": "2026-06-16T20:50:26+00:00"
         },
         {
             "name": "kalnoy/nestedset",
@@ -3838,20 +3830,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.13.0",
+            "version": "v13.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2"
+                "reference": "303b5f8dc899f89e8c38c350b639b8fbd193ed16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/303b5f8dc899f89e8c38c350b639b8fbd193ed16",
+                "reference": "303b5f8dc899f89e8c38c350b639b8fbd193ed16",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -3926,6 +3918,7 @@
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
+                "illuminate/image": "self.version",
                 "illuminate/json-schema": "self.version",
                 "illuminate/log": "self.version",
                 "illuminate/macroable": "self.version",
@@ -3952,6 +3945,7 @@
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
                 "guzzlehttp/psr7": "^2.9",
+                "intervention/image": "^4.0",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
                 "league/flysystem-ftp": "^3.25.1",
@@ -3988,6 +3982,7 @@
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0 || ^5.0 || ^6.0).",
                 "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
+                "intervention/image": "Required to use the image processing features (^4.0).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
                 "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.25.1).",
@@ -4058,7 +4053,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-02T14:28:17+00:00"
+            "time": "2026-07-21T14:27:35+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -4365,16 +4360,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.18",
+            "version": "v0.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
-                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
                 "shasum": ""
             },
             "require": {
@@ -4418,9 +4413,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
-            "time": "2026-05-19T00:47:18+00:00"
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "laravel/reverb",
@@ -4622,16 +4617,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.13",
+            "version": "v2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/dccd8bcb851bb03fcc005df650b708b57cc52661",
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661",
                 "shasum": ""
             },
             "require": {
@@ -4679,7 +4674,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-04-16T14:03:50+00:00"
+            "time": "2026-07-21T16:49:22+00:00"
         },
         {
             "name": "laravel/socialite",
@@ -4824,16 +4819,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
                 "shasum": ""
             },
             "require": {
@@ -4855,8 +4850,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -4927,7 +4922,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-07-12T15:29:16+00:00"
         },
         {
             "name": "league/config",
@@ -5104,16 +5099,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.34.0",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
-                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -5181,9 +5176,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2026-05-14T10:28:08+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -5236,16 +5231,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76",
                 "shasum": ""
             },
             "require": {
@@ -5255,7 +5250,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0 || ^11.0 || ^12.0"
             },
             "type": "library",
             "autoload": {
@@ -5276,7 +5271,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.17.0"
             },
             "funding": [
                 {
@@ -5288,7 +5283,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-21T08:32:55+00:00"
+            "time": "2026-07-09T11:49:27+00:00"
         },
         {
             "name": "league/oauth1-client",
@@ -5633,6 +5628,121 @@
             "time": "2026-03-08T20:05:35+00:00"
         },
         {
+            "name": "liberu-cms/cms-contracts",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-contracts",
+                "reference": "cda2f50df1f7c29803eddf3a21b29bed283faa9f"
+            },
+            "require": {
+                "php": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Contracts\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Contracts\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Interfaces, events, and DTOs shared across all Liberu CMS modules. Depended on by everything; depends on nothing.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-core",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-core",
+                "reference": "70dc5fec46c2bd9471a130bcc3f0ad7ca633b6be"
+            },
+            "require": {
+                "illuminate/console": "^13.0",
+                "illuminate/contracts": "^13.0",
+                "illuminate/database": "^13.0",
+                "illuminate/events": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-contracts": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Core\\CmsCoreServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Core\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Core\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "The Liberu CMS kernel: module registry, lifecycle manager, event bus, base module classes, and the module generator.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-hello",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-hello",
+                "reference": "45fa7447bc47bdf84865be864daa6ff6f983487d"
+            },
+            "require": {
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Hello\\HelloServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Hello\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Hello\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "A trivial proof-of-concept Liberu CMS module that exercises the whole pipeline: descriptor, isolation, contract, service, event, route, migration, config, and tests.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
             "name": "livewire/livewire",
             "version": "v4.3.1",
             "source": {
@@ -5950,16 +6060,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/2937ad3d1d2c506fd2bc97d571438a95641f44e2",
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2",
                 "shasum": ""
             },
             "require": {
@@ -6051,7 +6161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-07-09T18:23:49+00:00"
         },
         {
             "name": "nette/php-generator",
@@ -6196,16 +6306,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -6225,7 +6335,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -6281,26 +6391,25 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -6339,9 +6448,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -7005,16 +7114,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -7046,9 +7155,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -7843,20 +7952,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -7915,9 +8024,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "ratchet/rfc6455",
@@ -8666,16 +8775,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.11.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9a90eb5d32d5a500296bf43f946d60246444d5f7",
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7",
                 "shasum": ""
             },
             "require": {
@@ -8714,7 +8823,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.12.1"
             },
             "funding": [
                 {
@@ -8726,7 +8835,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-11T14:55:45+00:00"
+            "time": "2026-06-12T11:32:29+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -9730,16 +9839,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a"
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
                 "shasum": ""
             },
             "require": {
@@ -9806,7 +9915,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.0"
+                "source": "https://github.com/symfony/console/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -9826,7 +9935,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-16T12:55:20+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -9899,16 +10008,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -9946,7 +10055,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -9966,7 +10075,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -10051,16 +10160,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
@@ -10113,7 +10222,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10133,20 +10242,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -10193,7 +10302,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -10213,7 +10322,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -10288,16 +10397,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64"
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/58d2e767a66052c1487356f953445634a8194c64",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
                 "shasum": ""
             },
             "require": {
@@ -10332,7 +10441,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.0"
+                "source": "https://github.com/symfony/finder/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10352,7 +10461,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-27T09:05:56+00:00"
         },
         {
             "name": "symfony/html-sanitizer",
@@ -10428,16 +10537,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e"
+                "reference": "6a168c8fcee806b57ac020244da14293d1f9a883"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/af11474600f06718086c2cda4fa6fa8d0a672e7e",
-                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6a168c8fcee806b57ac020244da14293d1f9a883",
+                "reference": "6a168c8fcee806b57ac020244da14293d1f9a883",
                 "shasum": ""
             },
             "require": {
@@ -10485,7 +10594,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v8.1.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10505,20 +10614,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-12T08:43:41+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39"
+                "reference": "89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
-                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2",
+                "reference": "89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2",
                 "shasum": ""
             },
             "require": {
@@ -10594,7 +10703,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v8.1.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10614,20 +10723,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T08:46:08+00:00"
+            "time": "2026-06-27T09:27:36+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877"
+                "reference": "4fa583a7377f28d54e4de442fba76375b2e20a12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/9418d772df3a03a142e3bc06f602adb2b8724877",
-                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/4fa583a7377f28d54e4de442fba76375b2e20a12",
+                "reference": "4fa583a7377f28d54e4de442fba76375b2e20a12",
                 "shasum": ""
             },
             "require": {
@@ -10674,7 +10783,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v8.1.0"
+                "source": "https://github.com/symfony/mailer/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10694,7 +10803,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-16T12:55:20+00:00"
         },
         {
             "name": "symfony/mime",
@@ -11121,16 +11230,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -11182,7 +11291,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -11202,7 +11311,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -11450,16 +11559,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -11506,7 +11615,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -11526,7 +11635,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -12252,16 +12361,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "d101886195c5f772cf7033641fe9c40c3e3969e1"
+                "reference": "f911b744bc24658f435ea30439cfe536f0173a3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/d101886195c5f772cf7033641fe9c40c3e3969e1",
-                "reference": "d101886195c5f772cf7033641fe9c40c3e3969e1",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/f911b744bc24658f435ea30439cfe536f0173a3a",
+                "reference": "f911b744bc24658f435ea30439cfe536f0173a3a",
                 "shasum": ""
             },
             "require": {
@@ -12327,7 +12436,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v8.1.0"
+                "source": "https://github.com/symfony/serializer/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -12347,20 +12456,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-27T09:05:56+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -12414,7 +12523,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -12434,7 +12543,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
@@ -12528,16 +12637,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
@@ -12597,7 +12706,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -12617,20 +12726,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -12679,7 +12788,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -12699,7 +12808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/type-info",
@@ -12863,16 +12972,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e"
+                "reference": "40096a2515a979f3125c5c928603995b8664c62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/40096a2515a979f3125c5c928603995b8664c62a",
+                "reference": "40096a2515a979f3125c5c928603995b8664c62a",
                 "shasum": ""
             },
             "require": {
@@ -12926,7 +13035,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.1.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -12946,7 +13055,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T10:54:51+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -13074,16 +13183,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -13142,7 +13251,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -13154,7 +13263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -13389,16 +13498,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
-                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
@@ -13449,9 +13558,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2026-05-20T13:07:01+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "packages-dev": [
@@ -13547,6 +13656,94 @@
                 }
             ],
             "time": "2026-05-12T12:07:42+00:00"
+        },
+        {
+            "name": "colinodell/json5",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colinodell/json5.git",
+                "reference": "5724d21bc5c910c2560af1b8915f0cc0163579c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colinodell/json5/zipball/5724d21bc5c910c2560af1b8915f0cc0163579c8",
+                "reference": "5724d21bc5c910c2560af1b8915f0cc0163579c8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.7.0",
+                "phpstan/phpstan": "^1.10.57",
+                "scrutinizer/ocular": "^1.9",
+                "squizlabs/php_codesniffer": "^3.8.1",
+                "symfony/finder": "^6.0|^7.0",
+                "symfony/phpunit-bridge": "^7.0.3"
+            },
+            "bin": [
+                "bin/json5"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/global.php"
+                ],
+                "psr-4": {
+                    "ColinODell\\Json5\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "UTF-8 compatible JSON5 parser for PHP",
+            "homepage": "https://github.com/colinodell/json5",
+            "keywords": [
+                "JSON5",
+                "json",
+                "json5_decode",
+                "json_decode"
+            ],
+            "support": {
+                "issues": "https://github.com/colinodell/json5/issues",
+                "source": "https://github.com/colinodell/json5/tree/v3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-02-09T13:06:12+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -13795,6 +13992,417 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "infection/abstract-testframework-adapter",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/abstract-testframework-adapter.git",
+                "reference": "b24bf3e850f70cd20a10621f08c3cef66f147ac8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/abstract-testframework-adapter/zipball/b24bf3e850f70cd20a10621f08c3cef66f147ac8",
+                "reference": "b24bf3e850f70cd20a10621f08c3cef66f147ac8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.18",
+                "fidry/makefile": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.95.2",
+                "phpunit/phpunit": "^12.0 || ^13.0",
+                "rector/rector": "^2.4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\AbstractTestFramework\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Abstract Test Framework Adapter for Infection",
+            "support": {
+                "issues": "https://github.com/infection/abstract-testframework-adapter/issues",
+                "source": "https://github.com/infection/abstract-testframework-adapter/tree/0.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-05-28T19:10:29+00:00"
+        },
+        {
+            "name": "infection/extension-installer",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/extension-installer.git",
+                "reference": "9b351d2910b9a23ab4815542e93d541e0ca0cdcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/extension-installer/zipball/9b351d2910b9a23ab4815542e93d541e0ca0cdcf",
+                "reference": "9b351d2910b9a23ab4815542e93d541e0ca0cdcf",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.18, <2.19",
+                "infection/infection": "^0.15.2",
+                "php-coveralls/php-coveralls": "^2.4",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.10",
+                "phpstan/phpstan-phpunit": "^0.12.6",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpstan/phpstan-webmozart-assert": "^0.12.2",
+                "phpunit/phpunit": "^9.5",
+                "vimeo/psalm": "^4.8"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Infection\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Infection\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Infection Extension Installer",
+            "support": {
+                "issues": "https://github.com/infection/extension-installer/issues",
+                "source": "https://github.com/infection/extension-installer/tree/0.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-10-20T22:08:34+00:00"
+        },
+        {
+            "name": "infection/include-interceptor",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/include-interceptor.git",
+                "reference": "c083331bc0cd1cd319ac1b7a08e3ad4a34aa7992"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/include-interceptor/zipball/c083331bc0cd1cd319ac1b7a08e3ad4a34aa7992",
+                "reference": "c083331bc0cd1cd319ac1b7a08e3ad4a34aa7992",
+                "shasum": ""
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "infection/infection": "^0.19.0",
+                "phan/phan": "^2.4 || ^3",
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpstan/phpstan": "^0.12.8",
+                "phpunit/phpunit": "^8.5",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\StreamWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Stream Wrapper: Include Interceptor. Allows to replace included (autoloaded) file with another one.",
+            "support": {
+                "issues": "https://github.com/infection/include-interceptor/issues",
+                "source": "https://github.com/infection/include-interceptor/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-03T21:48:06+00:00"
+        },
+        {
+            "name": "infection/infection",
+            "version": "0.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/infection.git",
+                "reference": "373c2ab1689696ac6969013a04bdbccae74d7e08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/infection/zipball/373c2ab1689696ac6969013a04bdbccae74d7e08",
+                "reference": "373c2ab1689696ac6969013a04bdbccae74d7e08",
+                "shasum": ""
+            },
+            "require": {
+                "colinodell/json5": "^3.0",
+                "composer-runtime-api": "^2.0",
+                "composer/xdebug-handler": "^3.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "fidry/cpu-core-counter": "^1.0",
+                "infection/abstract-testframework-adapter": "^0.5.0",
+                "infection/extension-installer": "^0.1.0",
+                "infection/include-interceptor": "^0.2.5 || ^1.0.0",
+                "infection/mutator": "^0.4",
+                "justinrainbow/json-schema": "^6.0",
+                "nikic/php-parser": "^5.6.2",
+                "ondram/ci-detector": "^4.1.0",
+                "php": "^8.3",
+                "psr/log": "^2.0 || ^3.0",
+                "sanmai/di-container": "^0.1.16",
+                "sanmai/duoclock": "^0.1.0",
+                "sanmai/later": "^0.1.7",
+                "sanmai/pipeline": "^7.2",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "symfony/console": "^6.4 || ^7.4 || ^8.0",
+                "symfony/filesystem": "^6.4 || ^7.4 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.4 || ^8.0",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/process": "^6.4 || ^7.4 || ^8.0",
+                "thecodingmachine/safe": "^v3.0",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "conflict": {
+                "antecedent/patchwork": "<2.1.25",
+                "dg/bypass-finals": "<1.4.1"
+            },
+            "require-dev": {
+                "carthage-software/mago": "^1.20",
+                "ext-simplexml": "*",
+                "fidry/makefile": "^1.0",
+                "fig/log-test": "^1.2",
+                "phpat/phpat": "^0.12.4",
+                "phpbench/phpbench": "^1.4",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpstan/phpstan-webmozart-assert": "^2.0",
+                "phpunit/phpunit": "^11.5.27",
+                "rector/rector": "^2.2.4",
+                "shipmonk/dead-code-detector": "^0.15",
+                "shipmonk/name-collision-detector": "^2.1",
+                "sidz/phpstan-rules": "^0.5.1",
+                "symfony/yaml": "^6.4 || ^7.4 || ^8.0",
+                "thecodingmachine/phpstan-safe-rule": "^1.4",
+                "webmozarts/strict-phpunit": "^7.15"
+            },
+            "bin": [
+                "bin/infection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com",
+                    "homepage": "https://twitter.com/maks_rafalko"
+                },
+                {
+                    "name": "Oleg Zhulnev",
+                    "homepage": "https://github.com/sidz"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "homepage": "https://github.com/BackEndTea"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com",
+                    "homepage": "https://twitter.com/tfidry"
+                },
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com",
+                    "homepage": "https://www.alexeykopytko.com"
+                },
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Infection is a Mutation Testing framework for PHP. The mutation adequacy score can be used to measure the effectiveness of a test set in terms of its ability to detect faults.",
+            "keywords": [
+                "coverage",
+                "mutant",
+                "mutation framework",
+                "mutation testing",
+                "testing",
+                "unit testing"
+            ],
+            "support": {
+                "issues": "https://github.com/infection/infection/issues",
+                "source": "https://github.com/infection/infection/tree/0.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-06-28T12:05:47+00:00"
+        },
+        {
+            "name": "infection/mutator",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/mutator.git",
+                "reference": "3c976d721b02b32f851ee4e15d553ef1e9186d1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/mutator/zipball/3c976d721b02b32f851ee4e15d553ef1e9186d1d",
+                "reference": "3c976d721b02b32f851ee4e15d553ef1e9186d1d",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\Mutator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Mutator interface to implement custom mutators (mutation operators) for Infection",
+            "support": {
+                "issues": "https://github.com/infection/mutator/issues",
+                "source": "https://github.com/infection/mutator/tree/0.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-04-29T08:19:52+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -13853,6 +14461,96 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.2.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:00:58+00:00"
         },
         {
             "name": "laravel/boost",
@@ -14505,6 +15203,84 @@
             "time": "2026-04-21T14:04:20+00:00"
         },
         {
+            "name": "ondram/ci-detector",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OndraM/ci-detector.git",
+                "reference": "8b0223b5ed235fd377c75fdd1bfcad05c0f168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/8b0223b5ed235fd377c75fdd1bfcad05c0f168b8",
+                "reference": "8b0223b5ed235fd377c75fdd1bfcad05c0f168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.13.2",
+                "lmc/coding-standard": "^3.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.1.0",
+                "phpstan/phpstan": "^1.2.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpunit/phpunit": "^9.6.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OndraM\\CiDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Machulda",
+                    "email": "ondrej.machulda@gmail.com"
+                }
+            ],
+            "description": "Detect continuous integration environment and provide unified access to properties of current build",
+            "keywords": [
+                "CircleCI",
+                "Codeship",
+                "Wercker",
+                "adapter",
+                "appveyor",
+                "aws",
+                "aws codebuild",
+                "azure",
+                "azure devops",
+                "azure pipelines",
+                "bamboo",
+                "bitbucket",
+                "buddy",
+                "ci-info",
+                "codebuild",
+                "continuous integration",
+                "continuousphp",
+                "devops",
+                "drone",
+                "github",
+                "gitlab",
+                "interface",
+                "jenkins",
+                "pipelines",
+                "sourcehut",
+                "teamcity",
+                "travis"
+            ],
+            "support": {
+                "issues": "https://github.com/OndraM/ci-detector/issues",
+                "source": "https://github.com/OndraM/ci-detector/tree/4.2.0"
+            },
+            "time": "2024-03-12T13:22:30+00:00"
+        },
+        {
             "name": "pestphp/pest",
             "version": "5.x-dev",
             "source": {
@@ -15089,11 +15865,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.1",
+            "version": "2.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
-                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
                 "shasum": ""
             },
             "require": {
@@ -15149,20 +15925,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T14:44:12+00:00"
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.1.10",
+            "version": "14.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "3719c5b6c045761798238ebacfee1fe06e4ce5be"
+                "reference": "82f6e49ff224e2cde923d74425e583a883910783"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3719c5b6c045761798238ebacfee1fe06e4ce5be",
-                "reference": "3719c5b6c045761798238ebacfee1fe06e4ce5be",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/82f6e49ff224e2cde923d74425e583a883910783",
+                "reference": "82f6e49ff224e2cde923d74425e583a883910783",
                 "shasum": ""
             },
             "require": {
@@ -15170,7 +15946,7 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.7.0",
+                "nikic/php-parser": "^5.8.0",
                 "php": ">=8.4",
                 "phpunit/php-text-template": "^6.0",
                 "sebastian/complexity": "^6.0",
@@ -15181,7 +15957,7 @@
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1.13"
+                "phpunit/phpunit": "^13.2.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -15190,7 +15966,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "14.1.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -15219,7 +15995,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.3"
             },
             "funding": [
                 {
@@ -15239,7 +16015,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-01T13:26:42+00:00"
+            "time": "2026-07-06T15:04:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -15686,6 +16462,280 @@
             "time": "2026-05-26T21:03:22+00:00"
         },
         {
+            "name": "sanmai/di-container",
+            "version": "0.1.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/di-container.git",
+                "reference": "a901c4a8778c9212ef4d66607525281af2f787bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/di-container/zipball/a901c4a8778c9212ef4d66607525281af2f787bd",
+                "reference": "a901c4a8778c9212ef4d66607525281af2f787bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1.2 || ^2.0",
+                "sanmai/pipeline": "^6.17 || ^7.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "friendsofphp/php-cs-fixer": "^3.17",
+                "infection/infection": ">=0.31",
+                "php-coveralls/php-coveralls": "^2.4.1",
+                "phpbench/phpbench": "^1.4",
+                "phpstan/extension-installer": "^1.4",
+                "phpunit/phpunit": "^11.5.25",
+                "sanmai/phpstan-rules": "^0.3.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev"
+                },
+                "preferred-install": "dist"
+            },
+            "autoload": {
+                "psr-4": {
+                    "DIContainer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com",
+                    "homepage": "https://github.com/sanmai"
+                },
+                {
+                    "name": "Maks Rafalko",
+                    "homepage": "https://twitter.com/maks_rafalko"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "homepage": "https://twitter.com/tfidry"
+                }
+            ],
+            "description": "dependency injection container with automatic constructor dependency resolution",
+            "keywords": [
+                "Autowiring",
+                "constructor di",
+                "di container",
+                "psr 11"
+            ],
+            "support": {
+                "issues": "https://github.com/sanmai/di-container/issues",
+                "source": "https://github.com/sanmai/di-container/tree/0.1.17"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-01T08:52:14+00:00"
+        },
+        {
+            "name": "sanmai/duoclock",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/DuoClock.git",
+                "reference": "47461e3ff65b7308635047831a55615652e7be1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/DuoClock/zipball/47461e3ff65b7308635047831a55615652e7be1a",
+                "reference": "47461e3ff65b7308635047831a55615652e7be1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "friendsofphp/php-cs-fixer": "^3.17",
+                "infection/infection": ">=0.29",
+                "php-coveralls/php-coveralls": "^2.4.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^11.5.25",
+                "sanmai/phpstan-rules": "^0.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "preferred-install": "dist"
+            },
+            "autoload": {
+                "psr-4": {
+                    "DuoClock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "PHP time mocking for tests - PSR-20 clock with mockable sleep(), time(), and TimeSpy for PHPUnit testing",
+            "support": {
+                "issues": "https://github.com/sanmai/DuoClock/issues",
+                "source": "https://github.com/sanmai/DuoClock/tree/0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-26T06:12:34+00:00"
+        },
+        {
+            "name": "sanmai/later",
+            "version": "0.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/later.git",
+                "reference": "72a82d783864bca90412d8a26c1878f8981fee97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/later/zipball/72a82d783864bca90412d8a26c1878f8981fee97",
+                "reference": "72a82d783864bca90412d8a26c1878f8981fee97",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "friendsofphp/php-cs-fixer": "^3.35.1",
+                "infection/infection": ">=0.27.6",
+                "phan/phan": ">=2",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": ">=1.4.5",
+                "phpunit/phpunit": ">=9.5 <10",
+                "vimeo/psalm": ">=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Later\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "Later: deferred wrapper object",
+            "support": {
+                "issues": "https://github.com/sanmai/later/issues",
+                "source": "https://github.com/sanmai/later/tree/0.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-11T01:48:00+00:00"
+        },
+        {
+            "name": "sanmai/pipeline",
+            "version": "7.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/pipeline.git",
+                "reference": "d7046ecce91ae57fca403be694888371a21250eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/d7046ecce91ae57fca403be694888371a21250eb",
+                "reference": "d7046ecce91ae57fca403be694888371a21250eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "esi/phpunit-coverage-check": ">2",
+                "friendsofphp/php-cs-fixer": "^3.17",
+                "infection/infection": ">=0.32.3",
+                "league/pipeline": "^0.3 || ^1.0",
+                "php-coveralls/php-coveralls": "^2.4.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": ">=9.4 <12",
+                "sanmai/phpstan-rules": "^0.3.11",
+                "sanmai/phpunit-double-colon-syntax": "^0.1.1",
+                "vimeo/psalm": ">=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Pipeline\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "General-purpose collections pipeline",
+            "support": {
+                "issues": "https://github.com/sanmai/pipeline/issues",
+                "source": "https://github.com/sanmai/pipeline/tree/7.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-16T11:54:05+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "5.0.0",
             "source": {
@@ -16073,16 +17123,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.1.0",
+            "version": "8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6"
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c0d29a945f8cf82f300a05e69874508e307ca4c6",
-                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
                 "shasum": ""
             },
             "require": {
@@ -16091,7 +17141,7 @@
                 "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1.10"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
@@ -16139,7 +17189,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
             },
             "funding": [
                 {
@@ -16159,7 +17209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-21T11:50:56+00:00"
+            "time": "2026-07-13T11:35:11+00:00"
         },
         {
             "name": "sebastian/git-state",
@@ -16306,24 +17356,24 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7"
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
-                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.7.0",
+                "nikic/php-parser": "^5.8.0",
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1.10"
+                "phpunit/phpunit": "^13.2.4"
             },
             "type": "library",
             "extra": {
@@ -16352,7 +17402,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
             },
             "funding": [
                 {
@@ -16372,7 +17422,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T16:23:37+00:00"
+            "time": "2026-07-09T08:42:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -16777,16 +17827,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
                 "shasum": ""
             },
             "require": {
@@ -16829,7 +17879,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -16849,7 +17899,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -16909,6 +17959,149 @@
                 "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
             },
             "time": "2026-02-17T17:25:14+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: '8.3'
+        PHP_VERSION: '8.5'
         WWWUSER: '${WWWUSER:-1000}'
         WWWGROUP: '${WWWGROUP:-1000}'
     image: boilerplate-laravel:latest
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: '8.3'
+        PHP_VERSION: '8.5'
     image: boilerplate-laravel:latest
     environment:
       CONTAINER_MODE: worker
@@ -95,6 +95,23 @@ services:
     networks:
       - appnet
 
+  meilisearch:
+    image: getmeili/meilisearch:latest
+    ports:
+      - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+    environment:
+      MEILI_MASTER_KEY: '${MEILISEARCH_KEY:-masterKey}'
+      MEILI_NO_ANALYTICS: 'true'
+    volumes:
+      - meilisearch:/meili_data
+    networks:
+      - appnet
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--spider', 'http://localhost:7700/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 networks:
   appnet:
     driver: bridge
@@ -103,6 +120,8 @@ volumes:
   mysql:
     driver: local
   redis:
+    driver: local
+  meilisearch:
     driver: local
   storage:
     driver: local

--- a/docs/OPEN-QUESTIONS.md
+++ b/docs/OPEN-QUESTIONS.md
@@ -1,0 +1,61 @@
+# Open Questions
+
+Ambiguities and deferred decisions, per Part A §9. Each has a chosen default so
+work continues; revisit when the owning phase arrives.
+
+## Architecture & dependencies
+
+1. **`internachi/modular` is now unused.** Phase 0 hand-rolls
+   `packages/liberu-cms/*` (project decision). The `internachi/modular` package and
+   its `app-modules/` autoload/testsuite wiring remain installed but unused.
+   **Default:** leave installed for now. **Decision needed:** remove it (and the
+   `Modules\` autoload + `app-modules/*` phpunit entry) to avoid two module systems.
+
+2. **Filament Shield vs. `spatie/laravel-permission`.** Both are installed and the
+   existing app uses Spatie's `permission_tables` migration plus a `Role` model.
+   **Default:** unchanged in Phase 0. **Decision needed (Phase 1):** the Users
+   module exposes one permission contract; decide which library backs it and keep
+   the other from leaking across module boundaries (Golden Rule 2).
+
+3. **Existing host-app CMS code.** `app/Models` and `app/Filament` already contain
+   Page, Menu, Collection, Category, Tag, etc., violating Golden Rule 1 (feature
+   code in the host). **Default (agreed):** leave in place; migrate into modules in
+   their proper phases (Pages/Posts/Media → Phase 2, Menu/Theme → Phase 3), keeping
+   `main` green throughout.
+
+## Quality gates
+
+4. **Pre-existing style debt.** `vendor/bin/pint --test` flags many existing
+   `app/`, `config/`, `database/`, and `tests/` files. **Default:** the CI Pint gate
+   is scoped to Phase 0 code (`packages/liberu-cms`, `tests/*/Cms`), which is clean.
+   **Decision needed:** run repo-wide `pint` in a dedicated formatting commit.
+
+5. **PHPStan scope.** Max level runs on `packages/liberu-cms/*/src` only. **Decision
+   needed:** raise the pre-existing `app/` to a baseline (e.g. level 5) then climb.
+
+6. **Infection is non-blocking.** Local Herd PHP has no pcov/xdebug, so MSI could not
+   be measured here; the CI step runs with `continue-on-error: true`. **Decision
+   needed:** calibrate `minMsi`/`minCoveredMsi` against a real CI run, then make it
+   blocking.
+
+## Security
+
+7. **`audit.block-insecure: false`.** Enables the module `composer update` workflow
+   on this locked dev stack (upstream transitive advisories on guzzle, psr7,
+   composer/composer). `composer install` (CI) does not re-solve and is unaffected.
+   **Mitigation:** keep `composer audit` in `.github/workflows/security.yml` as the
+   reporting gate. **Decision needed:** revisit once upstream deps clear the
+   advisories.
+
+## Dev environment
+
+8. **PostgreSQL not in `docker-compose.yml`.** Compose ships MySQL + Redis +
+   Meilisearch + Mailpit. Database code is written portably (schema/query builder),
+   but the dev stack only spins up MySQL. **Default:** MySQL for dev. **Decision
+   needed:** add a `postgres` service behind a compose profile and run the suite
+   against both in CI (Phase 6 portability DoD).
+
+## Framework
+
+9. **Pest 5 vs Pest 4.** Guidelines mention Pest 4; the repo installs Pest 5.x-dev.
+   **Default:** build on Pest 5 (installed). No action expected.

--- a/docs/STACK.md
+++ b/docs/STACK.md
@@ -1,0 +1,58 @@
+# Stack
+
+The pinned technology stack for Liberu CMS, recorded per Part A §3. Versions are
+constrained in `composer.json`; actual resolved versions come from `composer.lock`.
+
+## Core runtime
+
+| Component | Target (Part B) | Constraint | Resolved / notes |
+|-----------|-----------------|------------|------------------|
+| PHP | 8.5 | `^8.5` | 8.5.8 (local Herd) |
+| Laravel | 13 | `^13.0` | 13.13.0 |
+| Filament | 5.x | `^5.0` | 5.x |
+| Livewire | 4 | `^4.0` | 4.x |
+| Database | PostgreSQL **and** MySQL | — | Portable via the schema/query builder; no vendor SQL |
+
+## Adopted ecosystem packages (Part A §3)
+
+| Package | Purpose | Boundary rule |
+|---------|---------|---------------|
+| `bezhansalleh/filament-shield` `^4.0` | RBAC / permissions | Phase 1: kept behind the Users module's permission contract |
+| `biostate/filament-menu-builder` `^5.0` | Navigation admin | Phase 3: kept behind the Menu module's contract |
+| `spatie/laravel-permission` `^7.0` | Permission storage | See open question on Shield vs. Spatie reconciliation |
+
+## Quality tooling
+
+| Tool | Version | Scope |
+|------|---------|-------|
+| Laravel Pint | `^1.24` | Phase 0 packages + CMS tests are clean; repo-wide debt tracked separately |
+| PHPStan + Larastan | `^2.2` / `^3.10` | **max** level on `packages/liberu-cms/*/src` |
+| Rector | `^2.4` | `app`, `database`, `packages/liberu-cms`, `tests` |
+| Pest | `5.x-dev` | Unit, Feature, and per-package `Modules` suites |
+| Infection | `^0.34` | Mutation testing on `cms-core` / `cms-contracts` (CI, non-blocking for now) |
+
+## Deviations from the source material
+
+1. **Pest 5, not Pest 4.** The repo already required `pestphp/pest:5.x-dev`; the
+   foundation guidelines mention Pest 4. We build on what is installed (Pest 5).
+2. **Module system: hand-rolled `packages/liberu-cms/*`.** `internachi/modular`
+   is installed but Phase 0 uses hand-rolled path-repository packages (namespace
+   `Liberu\Cms\*`) per an explicit project decision, matching Part A §4's literal
+   layout. See [OPEN-QUESTIONS](OPEN-QUESTIONS.md).
+3. **Laravel 13 confirmed.** The source material mentions both "Laravel 13"
+   (target) and "Laravel 12 foundation" in one place. Laravel 13 is viable and
+   installed, so 13 is the resolved target.
+4. **`config.audit.block-insecure: false`.** Required so the module workflow
+   (`composer update liberu-cms/*`) can re-solve on this locked dev stack, whose
+   upstream transitive deps carry advisories. `composer install` (CI) is
+   unaffected; advisories are still surfaced by `composer audit` in the security
+   workflow. Security tradeoff tracked in [OPEN-QUESTIONS](OPEN-QUESTIONS.md).
+5. **PHPStan scoped to the CMS packages.** Running max level over the pre-existing
+   `app/` would flood with findings unrelated to Phase 0; raising `app/` is future
+   work (tracked).
+
+## Dev environment (Docker / Sail)
+
+`docker-compose.yml` boots app (Octane/RoadRunner), queue worker, MySQL, Redis,
+Mailpit, and **Meilisearch** (search). PHP build arg corrected to 8.5. A
+PostgreSQL profile is not yet included — see [OPEN-QUESTIONS](OPEN-QUESTIONS.md).

--- a/docs/security/OWASP-AUDIT.md
+++ b/docs/security/OWASP-AUDIT.md
@@ -1,0 +1,182 @@
+# OWASP Top 10 Security Audit — Liberu CMS
+
+**Scope:** the existing application (auth, Filament admin panel, tenancy, public
+content rendering, uploads, configuration) as of branch `feature/cms-features`.
+**Method:** manual source review mapped to the OWASP Top 10 (2021), plus
+`composer audit`. This is a **report-first** deliverable; remediation follows in
+separate PRs. Severities are the auditor's assessment for a production deployment.
+
+## Summary
+
+| # | Category | Highest severity | Status |
+|---|----------|------------------|--------|
+| A01 | Broken Access Control | **High** | Findings — tenancy not enforced; sparse policies |
+| A02 | Cryptographic Failures | Low | Mostly sound |
+| A03 | Injection (XSS) | **High** | Stored XSS via unescaped content |
+| A04 | Insecure Design | Medium | Rich-content trust model; open registration |
+| A05 | Security Misconfiguration | Medium | `APP_DEBUG=true` shipped; audit blocking off |
+| A06 | Vulnerable & Outdated Components | Medium | 1 prod advisory; audit gate weakened |
+| A07 | Identification & Auth Failures | Low | Strong (2FA, passkeys, throttling) |
+| A08 | Software & Data Integrity Failures | Medium | Upload validation to confirm |
+| A09 | Logging & Monitoring Failures | Medium | No security audit log |
+| A10 | Server-Side Request Forgery | Info | No user-controlled fetches found |
+
+**Top priorities:** (1) fix stored XSS in content templates [A03], (2) enforce
+tenant isolation on the panel [A01] — being addressed in the multitenancy PR,
+(3) ship `APP_DEBUG=false` defaults and a production checklist [A05].
+
+---
+
+## A01 — Broken Access Control · **High**
+
+**Finding 1.1 — Tenancy is scaffolded but not enforced (High).**
+`AppPanelProvider` wires `->tenantMiddleware()`, Shield's
+`tenantOwnershipRelationshipName('teams')`, and `IsTenantModel` on models, but
+never calls `->tenant(Team::class)`. Filament's tenant auto-scoping therefore
+never engages, `SetPermissionsTeam` (which gates on `Filament::getTenant()`) is a
+no-op, and `IsTenantModel` adds only a `team()` relationship — no query scope. If
+tenancy is enabled, an authenticated user sees **every team's** Pages,
+Categories, Collections, Tags, and Menus.
+*Evidence:* `app/Providers/Filament/AppPanelProvider.php`,
+`app/Traits/IsTenantModel.php`, `app/Http/Middleware/SetPermissionsTeam.php`,
+`app/Filament/Resources/Pages/PageResource.php` (no `getEloquentQuery` scope).
+*Remediation:* enable `->tenant()`, add a tenant global scope, wire
+`HasTenants` on `User`, and add cross-tenant isolation tests. **In progress** in
+the multitenancy PR.
+
+**Finding 1.2 — Sparse authorization policies (Medium).**
+Only `ConnectedAccountPolicy` exists; CMS models (Page, Category, Collection,
+CollectionItem, Tag, Menu) rely entirely on Shield-generated permissions.
+*Remediation:* confirm Shield permission coverage for every resource and add
+model policies (or `->authorizeRecordsUsing`) so record-level checks are explicit,
+not implicit. Add feature tests asserting a low-privilege user is forbidden.
+
+**Finding 1.3 — Public routes are correctly unauthenticated (Info).**
+`routes/web.php` exposes `/`, `/{slug}`, `/{collection:slug}/{item:slug}` for
+public content — appropriate, but see A03 (their output is unescaped).
+
+---
+
+## A02 — Cryptographic Failures · **Low**
+
+Passwords are hashed with the framework default (bcrypt) via `Hash::make`;
+`Password::default()` governs strength; app data encryption uses `APP_KEY`.
+*Recommendations:* add `->uncompromised()` to password rules (HaveIBeenPwned
+check); enforce HTTPS in production (`URL::forceScheme('https')` / HSTS at the
+edge); confirm `SESSION_SECURE_COOKIE=true` in production.
+
+---
+
+## A03 — Injection · **High (Stored XSS)**
+
+**Finding 3.1 — Stored XSS via unescaped content (High).**
+Public templates render editor-authored content as raw HTML:
+`{!! $page->content !!}` in `resources/views/templates/default.blade.php:4` and
+`templates/home.blade.php:8`, and `{!! $item->content !!}` in
+`resources/views/item.blade.php:25`. Content is authored through the panel and
+served to unauthenticated visitors, so a malicious or compromised author can
+inject `<script>` that runs in every visitor's browser (session theft, defacement)
+— and in a multi-tenant deployment, across tenants.
+*Remediation:* sanitize rich HTML on save/render (e.g. `mews/purifier` or an
+allow-list), or store structured/Markdown content and render through a safe
+converter with escaping. Never `{!! !!}` untrusted content.
+
+**Finding 3.2 — No SQL injection observed (Info).**
+Data access is Eloquent throughout; the only `DB::` use is
+`DB::transaction(...)` in `CreateUserFromProvider`. No `whereRaw`/string-built
+queries found.
+
+---
+
+## A04 — Insecure Design · **Medium**
+
+- Rich content is trusted implicitly (root cause of A03) — the design lacks a
+  sanitization boundary between authoring and rendering.
+- Open self-registration (`->registration()` + Fortify) combined with unscoped
+  tenancy means new accounts’ default access needs an explicit model. Define what
+  team/role a self-registered user receives.
+*Remediation:* add a content-sanitization policy; document the registration →
+team/role assignment flow; consider gating registration behind invite for
+multi-tenant mode.
+
+---
+
+## A05 — Security Misconfiguration · **Medium**
+
+**Finding 5.1 — Debug enabled in shipped env (Medium).**
+`.env.example` sets `APP_DEBUG=true` and `APP_ENV=local`. A deployment copied
+from the example leaks stack traces and configuration in error pages.
+*Remediation:* ship `APP_DEBUG=false`, `APP_ENV=production` defaults for
+non-local, and add a production readiness checklist. `.env` is correctly
+gitignored.
+
+**Finding 5.2 — Advisory blocking disabled (Low).** `config.audit.block-insecure`
+is `false` (needed for the module `composer update` workflow). Acceptable given
+`composer audit` remains the reporting gate (see A06), but revisit once upstream
+advisories clear.
+
+---
+
+## A06 — Vulnerable & Outdated Components · **Medium**
+
+`composer audit --no-dev` reports **1 production advisory**:
+`phpseclib/phpseclib` (CVE-2026-55599, GHSA-m557-wrgg-6rp4). The full tree
+(including dev tooling) reports more. Because `block-insecure` is off, an insecure
+transitive dep will not fail `composer update`.
+*Remediation:* bump `phpseclib` to the patched release (via the requiring
+package); keep `composer audit` in `.github/workflows/security.yml` as a blocking
+CI gate; enable Dependabot (already present) auto-PRs.
+
+---
+
+## A07 — Identification & Authentication Failures · **Low**
+
+Strong posture: Fortify login throttling (5/min default, `config/fortify.php`),
+two-factor authentication (`stephenjude/filament-two-factor-authentication`),
+passkeys (`spatie/laravel-passkeys`), email verification support, and
+`AuthenticateSession` in the panel middleware.
+*Recommendations:* enforce 2FA for admin/privileged roles; add `->uncompromised()`
+to password rules; confirm password-reset and email-verification throttles.
+
+---
+
+## A08 — Software & Data Integrity Failures · **Medium**
+
+Uploads exist via Filament `FileUpload` in `CategoryForm` (`image`) and
+`UserForm` (`profile_photo_path`).
+*Remediation:* confirm each upload constrains MIME type and size
+(`->image()`, `->maxSize()`, `->acceptedFileTypes()`), stores outside the webroot
+or on a non-executable disk, and randomizes filenames. When the Media module
+lands (Phase 2), centralize secure-upload rules there. No insecure deserialization
+found.
+
+---
+
+## A09 — Security Logging & Monitoring Failures · **Medium**
+
+No audit logging of security-relevant events (logins, permission/role changes,
+content publish/unpublish, tenant switches). Part B §18 requires audit logging.
+*Remediation:* add an audit-log listener on auth and content events (the Phase 0
+`EventBus` gives a natural seam), ship with tamper-evident storage, and alert on
+anomalies.
+
+---
+
+## A10 — Server-Side Request Forgery · **Info**
+
+No user-controlled outbound URL fetching found. Socialstream performs
+provider-side OAuth calls to fixed endpoints. Re-audit when integrations (webhooks,
+remote media import, WordPress migration in Phase 6) are added.
+
+---
+
+## Remediation backlog (priority order)
+
+1. **[A03] Sanitize/escape content rendering** — remove `{!! $content !!}` XSS.
+2. **[A01] Enforce tenant isolation on the panel** — *in progress (multitenancy PR)*.
+3. **[A05] Production config defaults + checklist** — `APP_DEBUG=false`, HTTPS/HSTS.
+4. **[A01] Resource policies + Shield coverage tests.**
+5. **[A06] Patch `phpseclib`; make `composer audit` a blocking CI gate.**
+6. **[A09] Audit-logging via the EventBus.**
+7. **[A08] Confirm/enforce upload validation.**
+8. **[A02/A07] `->uncompromised()` passwords; enforce 2FA for admins.**

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,25 @@
+{
+    // Mutation testing focused on the CMS kernel's business logic — the module
+    // manager, registry, and state resolution — where correctness matters most.
+    // Requires a coverage driver (pcov/xdebug); runs in CI, see .github/workflows.
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": [
+            "packages/liberu-cms/cms-core/src",
+            "packages/liberu-cms/cms-contracts/src"
+        ]
+    },
+    "mutators": {
+        "@default": true
+    },
+    "testFramework": "pest",
+    "testFrameworkOptions": "--testsuite=Unit,Modules",
+    "minMsi": 80,
+    "minCoveredMsi": 90,
+    "logs": {
+        "text": "storage/logs/infection.log",
+        "stryker": {
+            "report": "liberu-cms"
+        }
+    }
+}

--- a/packages/liberu-cms/cms-contracts/README.md
+++ b/packages/liberu-cms/cms-contracts/README.md
@@ -1,0 +1,39 @@
+# cms-contracts
+
+The shared vocabulary of Liberu CMS: interfaces, cross-module events, and DTOs.
+
+**Everything depends on this package; this package depends on nothing** (only PHP).
+It contains no framework code and no implementations, so it can be required by
+any Laravel application, module, or external consumer without pulling in the CMS.
+
+## What lives here
+
+| Namespace | Purpose |
+|-----------|---------|
+| `Liberu\Cms\Contracts\Module` | Module descriptor, registry, manager, and state-repository contracts that drive discovery, enable/disable, and boot ordering. |
+| `Liberu\Cms\Contracts\Events` | `CmsEvent` marker for cross-module events and the `EventBusInterface` they travel over. |
+
+## The rule this package enforces
+
+Modules communicate through the interfaces and events declared here — never by
+importing each other's concrete classes. If module A needs something from
+module B, the capability is expressed as a contract in this package and bound in
+the container by B. A resolves the contract; it never names B.
+
+## Key contracts
+
+- **`ModuleInterface`** — a module's metadata descriptor (`key`, `name`,
+  `version`, `dependencies`, `isFoundational`).
+- **`ModuleRegistryInterface`** — the catalogue of every known module.
+- **`ModuleManagerInterface`** — the authority on whether a module is enabled,
+  plus dependency-aware `enable()` / `disable()` and `bootOrder()`.
+- **`ModuleStateRepositoryInterface`** — persistence for enable/disable decisions.
+- **`EventBusInterface`** + **`CmsEvent`** — the type-safe cross-module event seam.
+
+## Consumed by
+
+`cms-core` (implements these), and every CMS module (depends on the interfaces).
+
+## Emits / listens
+
+None. This package defines event *types* but never dispatches or handles them.

--- a/packages/liberu-cms/cms-contracts/composer.json
+++ b/packages/liberu-cms/cms-contracts/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "liberu-cms/cms-contracts",
+    "description": "Interfaces, events, and DTOs shared across all Liberu CMS modules. Depended on by everything; depends on nothing.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Contracts\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Contracts\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-contracts/src/Events/CmsEvent.php
+++ b/packages/liberu-cms/cms-contracts/src/Events/CmsEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Events;
+
+/**
+ * Marker for every event that crosses a module boundary.
+ *
+ * Cross-module communication happens only through events implementing this
+ * interface, dispatched via the EventBus. A module emits; other modules listen.
+ * Neither side imports the other's concrete classes.
+ */
+interface CmsEvent
+{
+    /**
+     * Stable dot-notation name of the event, e.g. "hello.greeted",
+     * "pages.published". Used for logging, webhooks, and cross-app transport.
+     */
+    public function name(): string;
+}

--- a/packages/liberu-cms/cms-contracts/src/Events/EventBusInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Events/EventBusInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Events;
+
+use Closure;
+
+/**
+ * The single seam through which modules broadcast and observe cross-module
+ * events. Wrapping the framework dispatcher keeps the boundary type-safe
+ * (only CmsEvent instances cross it) and provides one place to later add
+ * cross-application transport without touching any module.
+ */
+interface EventBusInterface
+{
+    /**
+     * Dispatch a cross-module event to all registered listeners.
+     */
+    public function dispatch(CmsEvent $event): void;
+
+    /**
+     * Register a listener for a cross-module event class.
+     *
+     * @param  class-string<CmsEvent>  $eventClass
+     * @param  Closure|class-string|array{0: class-string, 1: string}  $listener
+     */
+    public function listen(string $eventClass, Closure|string|array $listener): void;
+}

--- a/packages/liberu-cms/cms-contracts/src/Module/ModuleDependencyExceptionInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Module/ModuleDependencyExceptionInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Module;
+
+use Throwable;
+
+/**
+ * Marks failures caused by module dependency or lifecycle rule violations,
+ * so callers can catch a stable contract type rather than a concrete class.
+ */
+interface ModuleDependencyExceptionInterface extends Throwable {}

--- a/packages/liberu-cms/cms-contracts/src/Module/ModuleInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Module/ModuleInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Module;
+
+/**
+ * Describes a single CMS module to the core registry.
+ *
+ * A module ships exactly one implementation of this contract (its descriptor).
+ * The descriptor carries only metadata; it never performs work. Discovery,
+ * enable/disable, and boot ordering are driven from the values returned here.
+ */
+interface ModuleInterface
+{
+    /**
+     * Stable machine key, e.g. "hello", "pages", "media".
+     *
+     * Used as the primary identifier across the registry, state storage,
+     * dependency graph, and config. Must be unique and never change once shipped.
+     */
+    public function key(): string;
+
+    /**
+     * Human-readable module name for admin surfaces.
+     */
+    public function name(): string;
+
+    /**
+     * Semantic version of the module, independent of every other module.
+     */
+    public function version(): string;
+
+    /**
+     * Keys of the modules this module requires to be enabled before it may boot.
+     *
+     * @return array<int, string>
+     */
+    public function dependencies(): array;
+
+    /**
+     * Whether this module is part of the non-removable foundation.
+     *
+     * Foundational modules cannot be disabled through the module manager.
+     */
+    public function isFoundational(): bool;
+}

--- a/packages/liberu-cms/cms-contracts/src/Module/ModuleManagerInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Module/ModuleManagerInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Module;
+
+/**
+ * Governs module lifecycle: enable/disable, dependency rules, and boot order.
+ *
+ * The manager is the single authority other systems consult to decide whether
+ * a module's functionality should load. Modules never inspect each other's
+ * state directly; they ask the manager.
+ */
+interface ModuleManagerInterface
+{
+    /**
+     * Whether the module's functionality should currently load and run.
+     *
+     * Foundational modules always report true. Unknown modules report false.
+     */
+    public function isEnabled(string $key): bool;
+
+    /**
+     * Enable a module.
+     *
+     * @throws ModuleDependencyExceptionInterface
+     *                                            when a required dependency is missing or disabled.
+     */
+    public function enable(string $key): void;
+
+    /**
+     * Disable a module.
+     *
+     * @throws ModuleDependencyExceptionInterface
+     *                                            when the module is foundational, or an enabled module depends on it.
+     */
+    public function disable(string $key): void;
+
+    /**
+     * Keys of every enabled module in a safe boot order (dependencies first).
+     *
+     * @return array<int, string>
+     */
+    public function bootOrder(): array;
+
+    /**
+     * Keys of every module the given module depends on, transitively.
+     *
+     * @return array<int, string>
+     */
+    public function dependenciesOf(string $key): array;
+
+    /**
+     * Keys of enabled modules that depend on the given module, transitively.
+     *
+     * @return array<int, string>
+     */
+    public function dependentsOf(string $key): array;
+}

--- a/packages/liberu-cms/cms-contracts/src/Module/ModuleRegistryInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Module/ModuleRegistryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Module;
+
+/**
+ * Read model of every module known to the application.
+ *
+ * Each module's service provider registers its descriptor here during boot,
+ * regardless of enabled state, so the dependency graph is always complete.
+ */
+interface ModuleRegistryInterface
+{
+    /**
+     * Announce a module's existence to the registry.
+     */
+    public function register(ModuleInterface $module): void;
+
+    /**
+     * Whether a module with the given key has been registered.
+     */
+    public function has(string $key): bool;
+
+    /**
+     * Resolve a registered module descriptor by key, or null when unknown.
+     */
+    public function get(string $key): ?ModuleInterface;
+
+    /**
+     * All registered module descriptors, keyed by module key.
+     *
+     * @return array<string, ModuleInterface>
+     */
+    public function all(): array;
+}

--- a/packages/liberu-cms/cms-contracts/src/Module/ModuleStateRepositoryInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Module/ModuleStateRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Module;
+
+/**
+ * Persists the enabled/disabled decision for each toggleable module.
+ *
+ * Implementations must degrade gracefully: when backing storage is not yet
+ * available (e.g. before migrations run), reads fall back to the default so
+ * the application still boots.
+ */
+interface ModuleStateRepositoryInterface
+{
+    /**
+     * Whether the module is enabled, using $default when no record exists.
+     */
+    public function isEnabled(string $key, bool $default = true): bool;
+
+    /**
+     * Persist an enabled/disabled decision for the module.
+     */
+    public function setEnabled(string $key, bool $enabled): void;
+
+    /**
+     * Drop any stored decision, reverting the module to its default state.
+     */
+    public function forget(string $key): void;
+}

--- a/packages/liberu-cms/cms-core/README.md
+++ b/packages/liberu-cms/cms-core/README.md
@@ -1,0 +1,63 @@
+# cms-core
+
+The Liberu CMS kernel. It turns a plain Laravel application into a host for
+independently installable, removable modules — standalone, embedded, or headless.
+
+Depends only on `cms-contracts` and the framework. It never depends on a module.
+
+## What it provides
+
+| Service (bound as singleton) | Contract | Responsibility |
+|------------------------------|----------|----------------|
+| `ModuleRegistry` | `ModuleRegistryInterface` | Catalogue of every module whose provider has booted. |
+| `ModuleManager` | `ModuleManagerInterface` | Enable/disable with dependency validation; topological boot order. |
+| `DatabaseModuleStateRepository` | `ModuleStateRepositoryInterface` | Persists enable/disable in `cms_modules`; degrades gracefully pre-migration. |
+| `EventBus` | `EventBusInterface` | Type-safe wrapper over the framework dispatcher for cross-module events. |
+
+Plus the base classes every module extends: `AbstractModule` (descriptor) and
+`ModuleServiceProvider` (self-gating isolation).
+
+## How a module stays isolated and removable
+
+A module's provider extends `ModuleServiceProvider`. It is always discovered by
+Laravel, but during `boot()` it:
+
+1. announces its descriptor to the registry (so the dependency graph is complete
+   even for disabled modules), then
+2. loads its routes, migrations, views, config, and listeners **only** when
+   `ModuleManager::isEnabled()` is true.
+
+Disabling a module leaves its provider registered but inert. Nothing else in the
+app changes, which is what makes "disable any module, suite stays green" true.
+
+## Enable / disable
+
+```php
+$manager = app(\Liberu\Cms\Contracts\Module\ModuleManagerInterface::class);
+
+$manager->isEnabled('hello');   // bool
+$manager->enable('hello');      // throws if a dependency is missing/disabled
+$manager->disable('hello');     // throws if foundational or an enabled module needs it
+$manager->bootOrder();          // ['contracts-first', ..., 'dependents-last']
+```
+
+Config-driven kill switch (ideal for embedded hosts) in `config/cms.php`:
+
+```php
+'disabled_modules' => ['hello'],
+```
+
+## Generate a module
+
+```bash
+php artisan cms:make-module Portfolio
+composer update liberu-cms/cms-portfolio
+php artisan migrate
+```
+
+The generated package under `packages/liberu-cms/cms-portfolio` conforms to the
+module contract and passes CI before you add a single feature.
+
+## Events
+
+- **Emits / Listens:** none. Core defines the bus; modules use it.

--- a/packages/liberu-cms/cms-core/composer.json
+++ b/packages/liberu-cms/cms-core/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "liberu-cms/cms-core",
+    "description": "The Liberu CMS kernel: module registry, lifecycle manager, event bus, base module classes, and the module generator.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "illuminate/console": "^13.0",
+        "illuminate/contracts": "^13.0",
+        "illuminate/database": "^13.0",
+        "illuminate/events": "^13.0",
+        "illuminate/support": "^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Core\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Core\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Core\\CmsCoreServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-core/config/cms.php
+++ b/packages/liberu-cms/cms-core/config/cms.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default module state
+    |--------------------------------------------------------------------------
+    |
+    | When a module has no stored enable/disable decision yet, this is the
+    | state it takes. Leaving this true means modules are on by default and
+    | must be explicitly disabled.
+    |
+    */
+
+    'modules_enabled_by_default' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force-disabled modules
+    |--------------------------------------------------------------------------
+    |
+    | Module keys listed here are always disabled regardless of stored state.
+    | This gives the host application (especially in embedded mode) a static,
+    | config-driven kill switch that never touches another module's code.
+    |
+    */
+
+    'disabled_modules' => [],
+
+];

--- a/packages/liberu-cms/cms-core/database/migrations/2026_01_01_000000_create_cms_modules_table.php
+++ b/packages/liberu-cms/cms-core/database/migrations/2026_01_01_000000_create_cms_modules_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cms_modules', function (Blueprint $table): void {
+            $table->string('key')->primary();
+            $table->boolean('enabled')->default(true);
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_modules');
+    }
+};

--- a/packages/liberu-cms/cms-core/src/CmsCoreServiceProvider.php
+++ b/packages/liberu-cms/cms-core/src/CmsCoreServiceProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Support\ServiceProvider;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+use Liberu\Cms\Contracts\Module\ModuleStateRepositoryInterface;
+use Liberu\Cms\Core\Console\MakeModuleCommand;
+use Liberu\Cms\Core\Events\EventBus;
+use Liberu\Cms\Core\Module\DatabaseModuleStateRepository;
+use Liberu\Cms\Core\Module\ModuleManager;
+use Liberu\Cms\Core\Module\ModuleRegistry;
+
+/**
+ * The CMS kernel provider.
+ *
+ * Registers the registry, state repository, manager, and event bus as
+ * singletons so every module and the host application resolve the same
+ * instances. It is registered before module providers interact with these
+ * services because Laravel completes all register() calls before any boot().
+ */
+final class CmsCoreServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/cms.php', 'cms');
+
+        $this->app->singleton(ModuleRegistryInterface::class, ModuleRegistry::class);
+
+        $this->app->singleton(ModuleStateRepositoryInterface::class, fn (): DatabaseModuleStateRepository => new DatabaseModuleStateRepository($this->app->make(ConnectionResolverInterface::class)));
+
+        $this->app->singleton(ModuleManagerInterface::class, function (): ModuleManager {
+            $config = $this->app->make(ConfigRepository::class);
+
+            return new ModuleManager(
+                registry: $this->app->make(ModuleRegistryInterface::class),
+                state: $this->app->make(ModuleStateRepositoryInterface::class),
+                enabledByDefault: (bool) $config->get('cms.modules_enabled_by_default', true),
+                forcedDisabled: $this->disabledModules($config),
+            );
+        });
+
+        $this->app->singleton(EventBusInterface::class, fn (): EventBus => new EventBus($this->app->make(Dispatcher::class)));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function disabledModules(ConfigRepository $config): array
+    {
+        $disabled = $config->get('cms.disabled_modules', []);
+
+        if (! is_array($disabled)) {
+            return [];
+        }
+
+        return array_values(array_filter($disabled, is_string(...)));
+    }
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/cms.php' => $this->app->configPath('cms.php'),
+            ], 'cms-config');
+
+            $this->commands([
+                MakeModuleCommand::class,
+            ]);
+        }
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Console/MakeModuleCommand.php
+++ b/packages/liberu-cms/cms-core/src/Console/MakeModuleCommand.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+/**
+ * Scaffolds a new, §5-conforming CMS module package under
+ * packages/liberu-cms/cms-{key} and wires it into the root composer.json.
+ *
+ * The generated module boots, enables, and disables out of the box, so it can
+ * pass CI before a single feature is written.
+ */
+final class MakeModuleCommand extends Command
+{
+    #[\Override]
+    protected $signature = 'cms:make-module
+        {name : The module name, e.g. Portfolio}
+        {--foundational : Mark the module as non-removable}';
+
+    #[\Override]
+    protected $description = 'Generate a new Liberu CMS module package';
+
+    public function __construct(private readonly Filesystem $files)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $studly = Str::studly($this->argument('name'));
+        $key = Str::kebab($studly);
+        $foundational = (bool) $this->option('foundational');
+
+        $base = base_path("packages/liberu-cms/cms-{$key}");
+
+        if ($this->files->isDirectory($base)) {
+            $this->components->error("Module [cms-{$key}] already exists at {$base}.");
+
+            return self::FAILURE;
+        }
+
+        foreach ([$base, "{$base}/src", "{$base}/config", "{$base}/routes", "{$base}/database/migrations", "{$base}/tests"] as $dir) {
+            $this->files->ensureDirectoryExists($dir);
+        }
+
+        $replacements = [
+            '{{studly}}' => $studly,
+            '{{key}}' => $key,
+            '{{namespace}}' => "Liberu\\Cms\\{$studly}",
+            '{{foundational}}' => $foundational ? 'true' : 'false',
+        ];
+
+        $this->writeComposerJson($base, $studly, $key);
+        $this->write("{$base}/README.md", $this->readmeStub(), $replacements);
+        $this->write("{$base}/config/{$key}.php", $this->configStub(), $replacements);
+        $this->write("{$base}/routes/api.php", $this->routesStub(), $replacements);
+        $this->write("{$base}/src/{$studly}Module.php", $this->moduleStub(), $replacements);
+        $this->write("{$base}/src/{$studly}ServiceProvider.php", $this->providerStub(), $replacements);
+        $this->write("{$base}/tests/{$studly}ModuleTest.php", $this->testStub(), $replacements);
+        $this->files->put("{$base}/database/migrations/.gitkeep", '');
+
+        $this->addToRootComposer($key);
+
+        $this->components->info("Module [cms-{$key}] created at packages/liberu-cms/cms-{$key}.");
+        $this->components->bulletList([
+            'Run: composer update liberu-cms/cms-'.$key,
+            'Then: php artisan migrate',
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, string>  $replacements
+     */
+    private function write(string $path, string $stub, array $replacements): void
+    {
+        $this->files->put($path, strtr($stub, $replacements));
+    }
+
+    private function addToRootComposer(string $key): void
+    {
+        $path = base_path('composer.json');
+
+        $decoded = json_decode($this->files->get($path), true);
+        $composer = is_array($decoded) ? $decoded : [];
+
+        /** @var array<string, string> $require */
+        $require = is_array($composer['require'] ?? null) ? $composer['require'] : [];
+        $require["liberu-cms/cms-{$key}"] = '*';
+        ksort($require);
+        $composer['require'] = $require;
+
+        $this->files->put(
+            $path,
+            json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n",
+        );
+    }
+
+    private function writeComposerJson(string $base, string $studly, string $key): void
+    {
+        $namespace = "Liberu\\Cms\\{$studly}\\";
+
+        $composer = [
+            'name' => "liberu-cms/cms-{$key}",
+            'description' => "The {$studly} module for Liberu CMS.",
+            'type' => 'library',
+            'license' => 'MIT',
+            'version' => '0.1.0',
+            'require' => [
+                'php' => '^8.5',
+                'liberu-cms/cms-contracts' => '*',
+                'liberu-cms/cms-core' => '*',
+            ],
+            'autoload' => ['psr-4' => [$namespace => 'src/']],
+            'autoload-dev' => ['psr-4' => ["{$namespace}Tests\\" => 'tests/']],
+            'extra' => ['laravel' => ['providers' => ["{$namespace}{$studly}ServiceProvider"]]],
+            'minimum-stability' => 'dev',
+            'prefer-stable' => true,
+        ];
+
+        $this->files->put(
+            "{$base}/composer.json",
+            json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n",
+        );
+    }
+
+    private function moduleStub(): string
+    {
+        return <<<'STUB'
+        <?php
+
+        declare(strict_types=1);
+
+        namespace {{namespace}};
+
+        use Liberu\Cms\Core\Module\AbstractModule;
+
+        final class {{studly}}Module extends AbstractModule
+        {
+            public function key(): string
+            {
+                return '{{key}}';
+            }
+
+            public function name(): string
+            {
+                return '{{studly}}';
+            }
+
+            public function version(): string
+            {
+                return '0.1.0';
+            }
+
+            public function isFoundational(): bool
+            {
+                return {{foundational}};
+            }
+        }
+
+        STUB;
+    }
+
+    private function providerStub(): string
+    {
+        return <<<'STUB'
+        <?php
+
+        declare(strict_types=1);
+
+        namespace {{namespace}};
+
+        use Liberu\Cms\Contracts\Module\ModuleInterface;
+        use Liberu\Cms\Core\Module\ModuleServiceProvider;
+
+        final class {{studly}}ServiceProvider extends ModuleServiceProvider
+        {
+            public function module(): ModuleInterface
+            {
+                return new {{studly}}Module;
+            }
+
+            protected function registerModule(): void
+            {
+                $this->mergeModuleConfig(__DIR__.'/../config/{{key}}.php', '{{key}}');
+            }
+
+            protected function bootModule(): void
+            {
+                $this->loadModuleMigrations(__DIR__.'/../database/migrations');
+                $this->loadModuleRoutesFrom(__DIR__.'/../routes/api.php');
+            }
+        }
+
+        STUB;
+    }
+
+    private function configStub(): string
+    {
+        return <<<'STUB'
+        <?php
+
+        declare(strict_types=1);
+
+        return [
+            //
+        ];
+
+        STUB;
+    }
+
+    private function routesStub(): string
+    {
+        return <<<'STUB'
+        <?php
+
+        declare(strict_types=1);
+
+        use Illuminate\Support\Facades\Route;
+
+        Route::prefix('api/v1/{{key}}')->group(function (): void {
+            //
+        });
+
+        STUB;
+    }
+
+    private function testStub(): string
+    {
+        return <<<'STUB'
+        <?php
+
+        declare(strict_types=1);
+
+        use {{namespace}}\{{studly}}Module;
+
+        it('describes the {{key}} module', function (): void {
+            $module = new {{studly}}Module;
+
+            expect($module->key())->toBe('{{key}}')
+                ->and($module->name())->toBe('{{studly}}')
+                ->and($module->version())->not->toBeEmpty()
+                ->and($module->isFoundational())->toBeFalse();
+        });
+
+        STUB;
+    }
+
+    private function readmeStub(): string
+    {
+        return <<<'STUB'
+        # cms-{{key}}
+
+        The {{studly}} module for Liberu CMS.
+
+        ## Install
+
+        ```bash
+        composer update liberu-cms/cms-{{key}}
+        php artisan migrate
+        ```
+
+        ## Config keys
+
+        Published from `config/{{key}}.php` (merged under the `{{key}}` key).
+
+        ## Events
+
+        - **Emits:** _none yet_
+        - **Listens:** _none yet_
+
+        ## Public contracts
+
+        _none yet_
+
+        ## Extension points
+
+        _none yet_
+        STUB;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Events/EventBus.php
+++ b/packages/liberu-cms/cms-core/src/Events/EventBus.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Events;
+
+use Closure;
+use Illuminate\Contracts\Events\Dispatcher;
+use Liberu\Cms\Contracts\Events\CmsEvent;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+
+/**
+ * Thin, type-safe wrapper over the framework dispatcher.
+ *
+ * Only CmsEvent instances cross this seam, which keeps the module boundary
+ * honest and gives the platform a single place to later add cross-application
+ * transport (queue, webhook, message bus) without changing any module.
+ */
+final readonly class EventBus implements EventBusInterface
+{
+    public function __construct(private Dispatcher $dispatcher) {}
+
+    public function dispatch(CmsEvent $event): void
+    {
+        $this->dispatcher->dispatch($event);
+    }
+
+    public function listen(string $eventClass, Closure|string|array $listener): void
+    {
+        $this->dispatcher->listen($eventClass, $listener);
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Exceptions/ModuleDependencyException.php
+++ b/packages/liberu-cms/cms-core/src/Exceptions/ModuleDependencyException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Exceptions;
+
+use Liberu\Cms\Contracts\Module\ModuleDependencyExceptionInterface;
+use RuntimeException;
+
+final class ModuleDependencyException extends RuntimeException implements ModuleDependencyExceptionInterface
+{
+    public static function missingDependency(string $module, string $dependency): self
+    {
+        return new self("Cannot enable module [{$module}]: required module [{$dependency}] is not registered.");
+    }
+
+    public static function disabledDependency(string $module, string $dependency): self
+    {
+        return new self("Cannot enable module [{$module}]: required module [{$dependency}] is disabled.");
+    }
+
+    public static function hasEnabledDependents(string $module, string $dependent): self
+    {
+        return new self("Cannot disable module [{$module}]: enabled module [{$dependent}] depends on it.");
+    }
+
+    public static function foundational(string $module): self
+    {
+        return new self("Cannot disable module [{$module}]: it is foundational and always enabled.");
+    }
+
+    public static function unknown(string $module): self
+    {
+        return new self("Unknown module [{$module}]: it is not registered.");
+    }
+
+    public static function cycle(string $module): self
+    {
+        return new self("Dependency cycle detected involving module [{$module}].");
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/AbstractModule.php
+++ b/packages/liberu-cms/cms-core/src/Module/AbstractModule.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+
+/**
+ * Convenience base for module descriptors.
+ *
+ * A module ships a small subclass declaring its key, name, version, and
+ * dependencies. Foundational status defaults to false, so ordinary modules
+ * stay removable without any extra code.
+ */
+abstract class AbstractModule implements ModuleInterface
+{
+    public function dependencies(): array
+    {
+        return [];
+    }
+
+    public function isFoundational(): bool
+    {
+        return false;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/ArrayModuleStateRepository.php
+++ b/packages/liberu-cms/cms-core/src/Module/ArrayModuleStateRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Liberu\Cms\Contracts\Module\ModuleStateRepositoryInterface;
+
+/**
+ * In-memory module state, with no persistence.
+ *
+ * Useful for tests and for embedded hosts that prefer to drive module state
+ * from their own configuration rather than the cms_modules table.
+ */
+final class ArrayModuleStateRepository implements ModuleStateRepositoryInterface
+{
+    /**
+     * @param  array<string, bool>  $state
+     */
+    public function __construct(private array $state = []) {}
+
+    public function isEnabled(string $key, bool $default = true): bool
+    {
+        return $this->state[$key] ?? $default;
+    }
+
+    public function setEnabled(string $key, bool $enabled): void
+    {
+        $this->state[$key] = $enabled;
+    }
+
+    public function forget(string $key): void
+    {
+        unset($this->state[$key]);
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/DatabaseModuleStateRepository.php
+++ b/packages/liberu-cms/cms-core/src/Module/DatabaseModuleStateRepository.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Liberu\Cms\Contracts\Module\ModuleStateRepositoryInterface;
+use Throwable;
+
+/**
+ * Persists enable/disable decisions in the cms_modules table.
+ *
+ * Reads are memoised for the life of the instance (bound as a singleton) so a
+ * request pays at most one query. When the table is absent — a fresh install
+ * before migrations — every read falls back to the caller's default so the
+ * application still boots.
+ */
+final class DatabaseModuleStateRepository implements ModuleStateRepositoryInterface
+{
+    private const string TABLE = 'cms_modules';
+
+    /**
+     * Memoised enabled flags, keyed by module key. Absent key = not yet loaded.
+     *
+     * @var array<string, bool>
+     */
+    private array $cache = [];
+
+    private ?bool $tableExists = null;
+
+    public function __construct(private readonly ConnectionResolverInterface $db) {}
+
+    public function isEnabled(string $key, bool $default = true): bool
+    {
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        if (! $this->tableExists()) {
+            return $default;
+        }
+
+        try {
+            $value = $this->db->connection()
+                ->table(self::TABLE)
+                ->where('key', $key)
+                ->value('enabled');
+        } catch (Throwable) {
+            return $default;
+        }
+
+        if ($value === null) {
+            return $default;
+        }
+
+        return $this->cache[$key] = (bool) $value;
+    }
+
+    public function setEnabled(string $key, bool $enabled): void
+    {
+        if (! $this->tableExists()) {
+            return;
+        }
+
+        $this->db->connection()->table(self::TABLE)->updateOrInsert(
+            ['key' => $key],
+            ['enabled' => $enabled, 'updated_at' => now()],
+        );
+
+        $this->cache[$key] = $enabled;
+    }
+
+    public function forget(string $key): void
+    {
+        if ($this->tableExists()) {
+            $this->db->connection()->table(self::TABLE)->where('key', $key)->delete();
+        }
+
+        unset($this->cache[$key]);
+    }
+
+    private function tableExists(): bool
+    {
+        if ($this->tableExists === true) {
+            return true;
+        }
+
+        try {
+            $connection = $this->db->connection();
+
+            if (! $connection instanceof Connection) {
+                return false;
+            }
+
+            $exists = $connection->getSchemaBuilder()->hasTable(self::TABLE);
+        } catch (Throwable) {
+            return false;
+        }
+
+        if (! $exists) {
+            return false;
+        }
+
+        return $this->tableExists = true;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/ModuleManager.php
+++ b/packages/liberu-cms/cms-core/src/Module/ModuleManager.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+use Liberu\Cms\Contracts\Module\ModuleStateRepositoryInterface;
+use Liberu\Cms\Core\Exceptions\ModuleDependencyException;
+
+/**
+ * The single authority on module lifecycle.
+ *
+ * Enable/disable decisions are validated against the dependency graph before
+ * they are persisted, and boot order is derived by topological sort so a module
+ * never boots ahead of something it depends on.
+ */
+final readonly class ModuleManager implements ModuleManagerInterface
+{
+    /**
+     * @param  array<int, string>  $forcedDisabled  Module keys the host has statically disabled.
+     */
+    public function __construct(
+        private ModuleRegistryInterface $registry,
+        private ModuleStateRepositoryInterface $state,
+        private bool $enabledByDefault = true,
+        private array $forcedDisabled = [],
+    ) {}
+
+    public function isEnabled(string $key): bool
+    {
+        $module = $this->registry->get($key);
+
+        if (! $module instanceof ModuleInterface) {
+            return false;
+        }
+
+        if ($module->isFoundational()) {
+            return true;
+        }
+
+        if (in_array($key, $this->forcedDisabled, true)) {
+            return false;
+        }
+
+        return $this->state->isEnabled($key, $this->enabledByDefault);
+    }
+
+    public function enable(string $key): void
+    {
+        $module = $this->registry->get($key)
+            ?? throw ModuleDependencyException::unknown($key);
+
+        foreach ($module->dependencies() as $dependency) {
+            if (! $this->registry->has($dependency)) {
+                throw ModuleDependencyException::missingDependency($key, $dependency);
+            }
+
+            if (! $this->isEnabled($dependency)) {
+                throw ModuleDependencyException::disabledDependency($key, $dependency);
+            }
+        }
+
+        $this->state->setEnabled($key, true);
+    }
+
+    public function disable(string $key): void
+    {
+        $module = $this->registry->get($key)
+            ?? throw ModuleDependencyException::unknown($key);
+
+        if ($module->isFoundational()) {
+            throw ModuleDependencyException::foundational($key);
+        }
+
+        foreach ($this->registry->all() as $candidate) {
+            if ($candidate->key() === $key) {
+                continue;
+            }
+
+            if (in_array($key, $candidate->dependencies(), true) && $this->isEnabled($candidate->key())) {
+                throw ModuleDependencyException::hasEnabledDependents($key, $candidate->key());
+            }
+        }
+
+        $this->state->setEnabled($key, false);
+    }
+
+    public function bootOrder(): array
+    {
+        $order = [];
+        $visiting = [];
+
+        foreach ($this->registry->all() as $module) {
+            if ($this->isEnabled($module->key())) {
+                $this->visit($module->key(), $order, $visiting);
+            }
+        }
+
+        return array_values($order);
+    }
+
+    public function dependenciesOf(string $key): array
+    {
+        $resolved = [];
+        $this->collectDependencies($key, $resolved);
+
+        return array_keys($resolved);
+    }
+
+    public function dependentsOf(string $key): array
+    {
+        $dependents = [];
+
+        foreach ($this->registry->all() as $candidate) {
+            $candidateKey = $candidate->key();
+
+            if ($candidateKey === $key || ! $this->isEnabled($candidateKey)) {
+                continue;
+            }
+
+            if (in_array($key, $this->dependenciesOf($candidateKey), true)) {
+                $dependents[$candidateKey] = true;
+            }
+        }
+
+        return array_keys($dependents);
+    }
+
+    /**
+     * Depth-first topological visit that lists dependencies before dependents
+     * and rejects cycles.
+     *
+     * @param  array<string, string>  $order
+     * @param  array<string, bool>  $visiting
+     */
+    private function visit(string $key, array &$order, array &$visiting): void
+    {
+        if (isset($order[$key])) {
+            return;
+        }
+
+        if (isset($visiting[$key])) {
+            throw ModuleDependencyException::cycle($key);
+        }
+
+        $visiting[$key] = true;
+
+        $module = $this->registry->get($key);
+
+        if ($module instanceof ModuleInterface) {
+            foreach ($module->dependencies() as $dependency) {
+                if ($this->isEnabled($dependency)) {
+                    $this->visit($dependency, $order, $visiting);
+                }
+            }
+        }
+
+        unset($visiting[$key]);
+
+        $order[$key] = $key;
+    }
+
+    /**
+     * @param  array<string, bool>  $resolved
+     */
+    private function collectDependencies(string $key, array &$resolved): void
+    {
+        $module = $this->registry->get($key);
+
+        if (! $module instanceof ModuleInterface) {
+            return;
+        }
+
+        foreach ($module->dependencies() as $dependency) {
+            if (isset($resolved[$dependency])) {
+                continue;
+            }
+
+            $resolved[$dependency] = true;
+            $this->collectDependencies($dependency, $resolved);
+        }
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/ModuleRegistry.php
+++ b/packages/liberu-cms/cms-core/src/Module/ModuleRegistry.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+
+/**
+ * In-memory catalogue of every module whose service provider has booted.
+ *
+ * Registration is idempotent and happens for enabled and disabled modules
+ * alike, so the dependency graph the manager reasons over is always complete.
+ */
+final class ModuleRegistry implements ModuleRegistryInterface
+{
+    /**
+     * @var array<string, ModuleInterface>
+     */
+    private array $modules = [];
+
+    public function register(ModuleInterface $module): void
+    {
+        $this->modules[$module->key()] = $module;
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->modules[$key]);
+    }
+
+    public function get(string $key): ?ModuleInterface
+    {
+        return $this->modules[$key] ?? null;
+    }
+
+    public function all(): array
+    {
+        return $this->modules;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Module/ModuleServiceProvider.php
+++ b/packages/liberu-cms/cms-core/src/Module/ModuleServiceProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Module;
+
+use Illuminate\Support\ServiceProvider;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+
+/**
+ * Base service provider that gives every CMS module the same isolation
+ * behaviour and turns it into a self-gating, removable unit.
+ *
+ * A module's provider is always discovered by Laravel. During boot it announces
+ * its descriptor to the registry (so the dependency graph is complete even for
+ * disabled modules) and then loads its functionality only when the module
+ * manager reports it enabled. Disabling a module therefore leaves its provider
+ * registered but inert: no migrations, routes, views, config, or listeners load.
+ *
+ * Subclasses implement module() and override registerModule()/bootModule().
+ */
+abstract class ModuleServiceProvider extends ServiceProvider
+{
+    /**
+     * The module's descriptor.
+     */
+    abstract public function module(): ModuleInterface;
+
+    /**
+     * Container bindings for the module's own services.
+     *
+     * Runs unconditionally so contracts resolve even before boot; the bindings
+     * are inert until the module's functionality is loaded.
+     */
+    protected function registerModule(): void {}
+
+    /**
+     * Functionality loaded only when the module is enabled: routes, views,
+     * migrations, event listeners, and admin surfaces.
+     */
+    protected function bootModule(): void {}
+
+    #[\Override]
+    final public function register(): void
+    {
+        $this->registerModule();
+    }
+
+    final public function boot(): void
+    {
+        $this->app->make(ModuleRegistryInterface::class)->register($this->module());
+
+        if (! $this->moduleIsEnabled()) {
+            return;
+        }
+
+        $this->bootModule();
+    }
+
+    protected function moduleIsEnabled(): bool
+    {
+        return $this->app->make(ModuleManagerInterface::class)->isEnabled($this->module()->key());
+    }
+
+    protected function loadModuleMigrations(string $path): void
+    {
+        $this->loadMigrationsFrom($path);
+    }
+
+    protected function loadModuleRoutesFrom(string $path): void
+    {
+        if (file_exists($path)) {
+            $this->loadRoutesFrom($path);
+        }
+    }
+
+    protected function loadModuleViews(string $path, string $namespace): void
+    {
+        $this->loadViewsFrom($path, $namespace);
+    }
+
+    protected function loadModuleTranslations(string $path, string $namespace): void
+    {
+        $this->loadTranslationsFrom($path, $namespace);
+    }
+
+    protected function mergeModuleConfig(string $path, string $key): void
+    {
+        $this->mergeConfigFrom($path, $key);
+    }
+}

--- a/packages/liberu-cms/cms-hello/README.md
+++ b/packages/liberu-cms/cms-hello/README.md
@@ -1,0 +1,54 @@
+# cms-hello
+
+A trivial proof-of-concept module. It exists to exercise the entire module
+pipeline end to end and to be the module CI enables, disables, and re-enables.
+
+Non-foundational by design: the "disable any module and the app still boots"
+guarantee is verified against it.
+
+## What it demonstrates (the full §5 module contract)
+
+- **Descriptor** — `HelloModule` (key `hello`).
+- **Self-gating provider** — `HelloServiceProvider` extends `ModuleServiceProvider`.
+- **Own contract + service** — `GreeterInterface` bound to `Greeter`.
+- **Cross-module event** — `HelloGreeted` dispatched over the `EventBus`.
+- **Versioned API route** — `GET /api/v1/hello/{name?}`.
+- **Migration** — `hello_greetings`.
+- **Config** — `config/hello.php` (`hello.greeting`), publishable + merged.
+- **Tests** — unit + feature, including enable/disable.
+
+## Install
+
+```bash
+composer update liberu-cms/cms-hello
+php artisan migrate
+```
+
+## Try it
+
+```
+GET /api/v1/hello/ada  ->  { "module": "hello", "message": "Hello, ada!" }
+```
+
+## Config keys
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `hello.greeting` | `Hello, :name!` | Template; `:name` is substituted. |
+
+## Events
+
+- **Emits:** `Liberu\Cms\Hello\Events\HelloGreeted` (`hello.greeted`) — on every greeting.
+- **Listens:** none.
+
+## Public contracts
+
+- `Liberu\Cms\Hello\Contracts\GreeterInterface` — resolve to produce greetings.
+
+## Disable
+
+```php
+app(\Liberu\Cms\Contracts\Module\ModuleManagerInterface::class)->disable('hello');
+```
+
+The route 404s and the provider goes inert; the rest of the app is unaffected.

--- a/packages/liberu-cms/cms-hello/composer.json
+++ b/packages/liberu-cms/cms-hello/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "liberu-cms/cms-hello",
+    "description": "A trivial proof-of-concept Liberu CMS module that exercises the whole pipeline: descriptor, isolation, contract, service, event, route, migration, config, and tests.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Hello\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Hello\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Hello\\HelloServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-hello/config/hello.php
+++ b/packages/liberu-cms/cms-hello/config/hello.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Greeting template
+    |--------------------------------------------------------------------------
+    |
+    | The :name placeholder is replaced with the greeted name. Demonstrates a
+    | publishable, mergeable, module-scoped config value.
+    |
+    */
+
+    'greeting' => 'Hello, :name!',
+
+];

--- a/packages/liberu-cms/cms-hello/database/migrations/2026_01_01_000100_create_hello_greetings_table.php
+++ b/packages/liberu-cms/cms-hello/database/migrations/2026_01_01_000100_create_hello_greetings_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hello_greetings', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('message');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hello_greetings');
+    }
+};

--- a/packages/liberu-cms/cms-hello/routes/api.php
+++ b/packages/liberu-cms/cms-hello/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Liberu\Cms\Hello\Http\Controllers\HelloController;
+
+Route::get('api/v1/hello/{name?}', HelloController::class)->name('cms.hello.greet');

--- a/packages/liberu-cms/cms-hello/src/Contracts/GreeterInterface.php
+++ b/packages/liberu-cms/cms-hello/src/Contracts/GreeterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello\Contracts;
+
+/**
+ * The Hello module's own public contract.
+ *
+ * Bound in the container by the module's provider. Consumers resolve this
+ * interface rather than the concrete Greeter, demonstrating the pattern every
+ * module follows to expose capability without leaking implementation.
+ */
+interface GreeterInterface
+{
+    public function greet(string $name): string;
+}

--- a/packages/liberu-cms/cms-hello/src/Events/HelloGreeted.php
+++ b/packages/liberu-cms/cms-hello/src/Events/HelloGreeted.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello\Events;
+
+use Liberu\Cms\Contracts\Events\CmsEvent;
+
+/**
+ * Emitted over the EventBus whenever a greeting is produced. Other modules may
+ * listen for this without ever importing anything else from the Hello module.
+ */
+final readonly class HelloGreeted implements CmsEvent
+{
+    public function __construct(public string $name, public string $message) {}
+
+    public function name(): string
+    {
+        return 'hello.greeted';
+    }
+}

--- a/packages/liberu-cms/cms-hello/src/HelloModule.php
+++ b/packages/liberu-cms/cms-hello/src/HelloModule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Descriptor for the Hello proof-of-concept module.
+ *
+ * Deliberately non-foundational so the platform's "disable any module and the
+ * app still boots" guarantee is exercised against it in CI.
+ */
+final class HelloModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'hello';
+    }
+
+    public function name(): string
+    {
+        return 'Hello';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-hello/src/HelloServiceProvider.php
+++ b/packages/liberu-cms/cms-hello/src/HelloServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello;
+
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+use Liberu\Cms\Hello\Contracts\GreeterInterface;
+use Liberu\Cms\Hello\Services\Greeter;
+
+final class HelloServiceProvider extends ModuleServiceProvider
+{
+    public function module(): ModuleInterface
+    {
+        return new HelloModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/hello.php', 'hello');
+
+        $this->app->bind(GreeterInterface::class, function (): Greeter {
+            $greeting = config('hello.greeting', 'Hello, :name!');
+
+            return new Greeter(is_string($greeting) ? $greeting : 'Hello, :name!');
+        });
+    }
+
+    protected function bootModule(): void
+    {
+        $this->loadModuleMigrations(__DIR__.'/../database/migrations');
+        $this->loadModuleRoutesFrom(__DIR__.'/../routes/api.php');
+
+        $this->publishes([
+            __DIR__.'/../config/hello.php' => $this->app->configPath('hello.php'),
+        ], 'cms-hello-config');
+    }
+}

--- a/packages/liberu-cms/cms-hello/src/Http/Controllers/HelloController.php
+++ b/packages/liberu-cms/cms-hello/src/Http/Controllers/HelloController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Hello\Contracts\GreeterInterface;
+use Liberu\Cms\Hello\Events\HelloGreeted;
+use Liberu\Cms\Hello\Models\Greeting;
+
+/**
+ * Thin controller: it delegates the greeting to the module's service, records
+ * it, and announces the result on the event bus. No business logic lives here.
+ */
+final readonly class HelloController
+{
+    public function __construct(
+        private GreeterInterface $greeter,
+        private EventBusInterface $events,
+    ) {}
+
+    public function __invoke(string $name = 'world'): JsonResponse
+    {
+        $message = $this->greeter->greet($name);
+
+        Greeting::create(['name' => $name, 'message' => $message]);
+
+        $this->events->dispatch(new HelloGreeted($name, $message));
+
+        return new JsonResponse([
+            'module' => 'hello',
+            'message' => $message,
+        ]);
+    }
+}

--- a/packages/liberu-cms/cms-hello/src/Models/Greeting.php
+++ b/packages/liberu-cms/cms-hello/src/Models/Greeting.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $name
+ * @property string $message
+ */
+final class Greeting extends Model
+{
+    #[\Override]
+    protected $table = 'hello_greetings';
+
+    /**
+     * @var list<string>
+     */
+    #[\Override]
+    protected $fillable = ['name', 'message'];
+}

--- a/packages/liberu-cms/cms-hello/src/Services/Greeter.php
+++ b/packages/liberu-cms/cms-hello/src/Services/Greeter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Hello\Services;
+
+use Liberu\Cms\Hello\Contracts\GreeterInterface;
+
+final readonly class Greeter implements GreeterInterface
+{
+    public function __construct(private string $template) {}
+
+    public function greet(string $name): string
+    {
+        return str_replace(':name', $name, $this->template);
+    }
+}

--- a/packages/liberu-cms/cms-hello/tests/HelloModuleTest.php
+++ b/packages/liberu-cms/cms-hello/tests/HelloModuleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Hello\HelloModule;
+use Liberu\Cms\Hello\Services\Greeter;
+
+it('describes the hello module', function (): void {
+    $module = new HelloModule;
+
+    expect($module->key())->toBe('hello')
+        ->and($module->name())->toBe('Hello')
+        ->and($module->version())->not->toBeEmpty()
+        ->and($module->isFoundational())->toBeFalse()
+        ->and($module->dependencies())->toBe([]);
+});
+
+it('greets using its configured template', function (): void {
+    $greeter = new Greeter('Hi, :name!');
+
+    expect($greeter->greet('ada'))->toBe('Hi, ada!');
+});

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    level: max
+    paths:
+        - packages/liberu-cms/cms-contracts/src
+        - packages/liberu-cms/cms-core/src
+        - packages/liberu-cms/cms-hello/src
+    treatPhpDocTypesAsCertain: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,11 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
-    <testsuite name="Modules"><directory suffix="Test.php">./app-modules/*/tests</directory></testsuite></testsuites>
+    <testsuite name="Modules">
+            <directory suffix="Test.php">./app-modules/*/tests</directory>
+            <directory suffix="Test.php">./packages/liberu-cms/*/tests</directory>
+        </testsuite>
+    </testsuites>
     <source>
         <include>
             <directory>app</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="MULTITENANCY" value="true"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__.'/app',
         __DIR__.'/database',
+        __DIR__.'/packages/liberu-cms',
         __DIR__.'/tests',
     ])
     ->withPhpSets(php85: true)

--- a/tests/Feature/Cms/ArchitectureTest.php
+++ b/tests/Feature/Cms/ArchitectureTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Enforces the §6 dependency direction:
+ *
+ *   host ─▶ modules ─▶ cms-core ─▶ cms-contracts
+ *
+ * Arrows never point sideways (module → sibling module) or backward
+ * (core → module, contracts → anything). Communication across modules happens
+ * only through contracts and events, so a module's source may reference the
+ * Contracts and Core namespaces (and its own), never another module's.
+ */
+function cmsPackageNamespaces(): array
+{
+    $packages = [];
+
+    foreach (glob(base_path('packages/liberu-cms/*'), GLOB_ONLYDIR) as $dir) {
+        $composer = json_decode(file_get_contents("{$dir}/composer.json"), true);
+        $roots = array_keys($composer['autoload']['psr-4'] ?? []);
+
+        foreach ($roots as $root) {
+            $packages[rtrim($root, '\\')] = basename($dir);
+        }
+    }
+
+    return $packages;
+}
+
+/**
+ * @return array<int, string> Fully-qualified Liberu\Cms imports in the file.
+ */
+function cmsImports(string $file): array
+{
+    preg_match_all('/^\s*use\s+(Liberu\\\\Cms\\\\[A-Za-z0-9_\\\\]+)/m', file_get_contents($file), $matches);
+
+    return $matches[1] ?? [];
+}
+
+function cmsRootOf(string $fqcn, array $namespaces): ?string
+{
+    $best = null;
+
+    foreach (array_keys($namespaces) as $root) {
+        if (str_starts_with($fqcn, $root.'\\') && ($best === null || strlen($root) > strlen($best))) {
+            $best = $root;
+        }
+    }
+
+    return $best;
+}
+
+it('keeps module dependencies pointing only inward (no sideways or backward imports)', function (): void {
+    $namespaces = cmsPackageNamespaces();
+    $contracts = 'Liberu\Cms\Contracts';
+    $core = 'Liberu\Cms\Core';
+    $violations = [];
+
+    foreach ($namespaces as $ownRoot => $package) {
+        $src = base_path("packages/liberu-cms/{$package}/src");
+
+        if (! is_dir($src)) {
+            continue;
+        }
+
+        $allowed = match (true) {
+            $ownRoot === $contracts => [$contracts],
+            $ownRoot === $core => [$contracts, $core],
+            default => [$contracts, $core, $ownRoot],
+        };
+
+        foreach (Finder::create()->files()->in($src)->name('*.php') as $file) {
+            foreach (cmsImports($file->getRealPath()) as $import) {
+                $importedRoot = cmsRootOf($import, $namespaces);
+
+                if ($importedRoot !== null && ! in_array($importedRoot, $allowed, true)) {
+                    $violations[] = "{$package} imports {$import}";
+                }
+            }
+        }
+    }
+
+    expect($violations)->toBe([]);
+});
+
+it('discovers the three foundational Phase 0 packages', function (): void {
+    expect(cmsPackageNamespaces())
+        ->toHaveKeys(['Liberu\Cms\Contracts', 'Liberu\Cms\Core', 'Liberu\Cms\Hello']);
+});

--- a/tests/Feature/Cms/EmbeddabilityTest.php
+++ b/tests/Feature/Cms/EmbeddabilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+use Liberu\Cms\Hello\Contracts\GreeterInterface;
+use Liberu\Cms\Hello\Events\HelloGreeted;
+
+it('boots the CMS kernel inside a bare application', function (): void {
+    $app = makeBareCmsApp();
+
+    expect($app->make(ModuleRegistryInterface::class)->has('hello'))->toBeTrue()
+        ->and($app->make(ModuleManagerInterface::class)->isEnabled('hello'))->toBeTrue();
+});
+
+it('serves a module capability inside a bare application', function (): void {
+    $app = makeBareCmsApp();
+
+    $message = $app->make(GreeterInterface::class)->greet('ada');
+
+    expect($message)->toBe('Hello, ada!');
+});
+
+it('routes a module request inside a bare application', function (): void {
+    $app = makeBareCmsApp();
+
+    expect($app['router']->getRoutes()->getByName('cms.hello.greet'))->not->toBeNull();
+});
+
+it('delivers cross-module events over the bus inside a bare application', function (): void {
+    $app = makeBareCmsApp();
+    $received = null;
+
+    $bus = $app->make(EventBusInterface::class);
+    $bus->listen(HelloGreeted::class, function (HelloGreeted $event) use (&$received): void {
+        $received = $event;
+    });
+    $bus->dispatch(new HelloGreeted('ada', 'Hello, ada!'));
+
+    expect($received)->toBeInstanceOf(HelloGreeted::class)
+        ->and($received->name)->toBe('ada');
+});

--- a/tests/Feature/Cms/HelloRouteTest.php
+++ b/tests/Feature/Cms/HelloRouteTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Liberu\Cms\Hello\Events\HelloGreeted;
+
+uses(RefreshDatabase::class);
+
+it('serves a greeting, records it, and announces it on the bus', function (): void {
+    Event::fake([HelloGreeted::class]);
+
+    $response = $this->getJson('/api/v1/hello/ada');
+
+    $response->assertSuccessful()
+        ->assertJson(['module' => 'hello', 'message' => 'Hello, ada!']);
+
+    $this->assertDatabaseHas('hello_greetings', ['name' => 'ada', 'message' => 'Hello, ada!']);
+
+    Event::assertDispatched(HelloGreeted::class, fn (HelloGreeted $event): bool => $event->name === 'ada');
+});
+
+it('defaults the greeted name to world', function (): void {
+    Event::fake([HelloGreeted::class]);
+
+    $this->getJson('/api/v1/hello')
+        ->assertSuccessful()
+        ->assertJson(['message' => 'Hello, world!']);
+});
+
+it('loads the module migration while the module is enabled', function (): void {
+    expect(Schema::hasTable('hello_greetings'))->toBeTrue();
+});

--- a/tests/Feature/Cms/ModuleLifecycleTest.php
+++ b/tests/Feature/Cms/ModuleLifecycleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Core\Exceptions\ModuleDependencyException;
+
+uses(RefreshDatabase::class);
+
+it('enables a module by default', function (): void {
+    expect(app(ModuleManagerInterface::class)->isEnabled('hello'))->toBeTrue();
+});
+
+it('persists a disable decision in the cms_modules table', function (): void {
+    $manager = app(ModuleManagerInterface::class);
+
+    $manager->disable('hello');
+
+    expect($manager->isEnabled('hello'))->toBeFalse();
+    $this->assertDatabaseHas('cms_modules', ['key' => 'hello', 'enabled' => false]);
+});
+
+it('re-enables a previously disabled module', function (): void {
+    $manager = app(ModuleManagerInterface::class);
+
+    $manager->disable('hello');
+    $manager->enable('hello');
+
+    expect($manager->isEnabled('hello'))->toBeTrue();
+});
+
+it('rejects toggling an unknown module', function (): void {
+    expect(fn () => app(ModuleManagerInterface::class)->disable('ghost'))
+        ->toThrow(ModuleDependencyException::class);
+});
+
+it('keeps the application responsive after disabling a module', function (): void {
+    app(ModuleManagerInterface::class)->disable('hello');
+
+    $this->get('/login')->assertSuccessful();
+});

--- a/tests/Feature/Cms/RemovabilityTest.php
+++ b/tests/Feature/Cms/RemovabilityTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+
+it('boots the application with a module disabled', function (): void {
+    $app = makeBareCmsApp(disabledModules: ['hello']);
+
+    expect($app->make(ModuleManagerInterface::class)->isEnabled('hello'))->toBeFalse();
+});
+
+it('does not register a disabled module\'s routes', function (): void {
+    $app = makeBareCmsApp(disabledModules: ['hello']);
+
+    expect($app['router']->getRoutes()->getByName('cms.hello.greet'))->toBeNull();
+});
+
+it('still registers a disabled module in the registry so the graph stays complete', function (): void {
+    $app = makeBareCmsApp(disabledModules: ['hello']);
+
+    expect($app->make(ModuleRegistryInterface::class)->has('hello'))->toBeTrue();
+});
+
+it('keeps the kernel and other modules working when one module is disabled', function (): void {
+    $app = makeBareCmsApp(disabledModules: ['hello']);
+
+    expect($app->make(EventBusInterface::class))->not->toBeNull()
+        ->and($app->make(ModuleManagerInterface::class)->bootOrder())->not->toContain('hello');
+});

--- a/tests/Feature/Filament/TenantIsolationTest.php
+++ b/tests/Feature/Filament/TenantIsolationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Collections\CollectionResource;
+use App\Filament\Resources\Collections\Pages\ListCollections;
+use App\Filament\Resources\Pages\PageResource;
+use App\Filament\Resources\Pages\Pages\ListPages;
+use App\Models\Collection as CollectionModel;
+use App\Models\Page;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->create();
+    $this->teamA = Team::factory()->create(['user_id' => $this->owner->id]);
+    $this->teamB = Team::factory()->create(['user_id' => $this->owner->id]);
+
+    $this->actingAs($this->owner);
+
+    $panel = Filament::getPanel('app');
+    Filament::setCurrentPanel($panel);
+
+    // Register the tenancy scope + creation observer for the resources under
+    // test, mirroring what Panel::boot() does during a real request.
+    foreach ([PageResource::class, CollectionResource::class] as $resource) {
+        $resource::registerTenancyModelGlobalScope($panel);
+        $resource::observeTenancyModelCreation($panel);
+    }
+
+    Filament::setTenant($this->teamA);
+});
+
+/**
+ * Create a record while a given team is the active tenant so Filament's
+ * creation observer stamps that team onto it.
+ */
+function createForTeam(string $model, Team $team, array $attributes = []): mixed
+{
+    Filament::setTenant($team);
+
+    return $model::factory()->create($attributes);
+}
+
+it('lists only the current tenant\'s pages', function (): void {
+    $mine = createForTeam(Page::class, $this->teamA, ['user_id' => $this->owner->id]);
+    $other = createForTeam(Page::class, $this->teamB, ['user_id' => $this->owner->id]);
+
+    Filament::setTenant($this->teamA);
+
+    Livewire::test(ListPages::class)
+        ->assertCanSeeTableRecords([$mine])
+        ->assertCanNotSeeTableRecords([$other]);
+});
+
+it('isolates a second tenant-scoped resource the same way', function (): void {
+    $mine = createForTeam(CollectionModel::class, $this->teamA);
+    $other = createForTeam(CollectionModel::class, $this->teamB);
+
+    Filament::setTenant($this->teamA);
+
+    Livewire::test(ListCollections::class)
+        ->assertCanSeeTableRecords([$mine])
+        ->assertCanNotSeeTableRecords([$other]);
+});
+
+it('stamps the active tenant onto newly created records automatically', function (): void {
+    $page = createForTeam(Page::class, $this->teamB, ['user_id' => $this->owner->id]);
+
+    expect($page->team_id)->toBe($this->teamB->id);
+});
+
+it('excludes other tenants\' records from a scoped query', function (): void {
+    createForTeam(Page::class, $this->teamA, ['user_id' => $this->owner->id]);
+    createForTeam(Page::class, $this->teamB, ['user_id' => $this->owner->id]);
+
+    Filament::setTenant($this->teamA);
+
+    expect(Page::query()->pluck('team_id')->unique()->values()->all())
+        ->toBe([$this->teamA->id]);
+});
+
+it('denies access to a tenant the user does not belong to', function (): void {
+    auth()->logout();
+    $stranger = Team::factory()->create();
+    $this->actingAs($this->owner);
+
+    expect($this->owner->canAccessTenant($this->teamA))->toBeTrue()
+        ->and($this->owner->canAccessTenant($stranger))->toBeFalse();
+});
+
+it('exposes the user\'s teams as available tenants', function (): void {
+    $tenants = $this->owner->getTenants(Filament::getPanel('app'));
+
+    expect($tenants->pluck('id'))->toContain($this->teamA->id, $this->teamB->id);
+});
+
+it('gives a newly registered-style user a personal team via createPersonalTeam', function (): void {
+    $user = User::factory()->create();
+
+    $team = $user->createPersonalTeam();
+
+    expect($user->current_team_id)->toBe($team->id)
+        ->and($user->fresh()->belongsToTeam($team))->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,58 @@
 <?php
 
+use Illuminate\Config\Repository;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Facade;
+use Liberu\Cms\Core\CmsCoreServiceProvider;
+use Liberu\Cms\Hello\HelloServiceProvider;
 use Tests\TestCase;
 
 uses(TestCase::class)->in('Feature', 'Unit');
+
+/**
+ * Boot the CMS kernel and the Hello module inside a fresh, bare Laravel
+ * application that has none of this project's feature providers (Jetstream,
+ * Filament, Socialstream, …). This is the embeddability harness: if the CMS
+ * boots and serves here, it can be embedded inside any Laravel host.
+ *
+ * The facade application is repointed to the bare app only while its providers
+ * boot, so module routes register into the bare app's router, then restored.
+ *
+ * @param  array<int, string>  $disabledModules
+ */
+function makeBareCmsApp(array $disabledModules = []): Application
+{
+    $original = Facade::getFacadeApplication();
+
+    $app = new Application(sys_get_temp_dir().'/cms-bare-'.uniqid());
+    $app->instance('files', new Filesystem);
+    $app->instance('config', new Repository([
+        'cms' => [
+            'modules_enabled_by_default' => true,
+            'disabled_modules' => $disabledModules,
+        ],
+    ]));
+
+    $capsule = new Capsule;
+    $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+    $app->instance(ConnectionResolverInterface::class, $capsule->getDatabaseManager());
+
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication($app);
+
+    try {
+        $app->register(CmsCoreServiceProvider::class);
+        $app->register(HelloServiceProvider::class);
+        $app->boot();
+    } finally {
+        Facade::setFacadeApplication($original);
+        Facade::clearResolvedInstances();
+    }
+
+    $app['router']->getRoutes()->refreshNameLookups();
+
+    return $app;
+}

--- a/tests/Unit/Cms/ModuleManagerTest.php
+++ b/tests/Unit/Cms/ModuleManagerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Exceptions\ModuleDependencyException;
+use Liberu\Cms\Core\Module\AbstractModule;
+use Liberu\Cms\Core\Module\ArrayModuleStateRepository;
+use Liberu\Cms\Core\Module\ModuleManager;
+use Liberu\Cms\Core\Module\ModuleRegistry;
+
+function fakeModule(string $key, array $dependencies = [], bool $foundational = false): ModuleInterface
+{
+    return new class($key, $dependencies, $foundational) extends AbstractModule
+    {
+        public function __construct(
+            private string $moduleKey,
+            private array $moduleDependencies,
+            private bool $moduleFoundational,
+        ) {}
+
+        public function key(): string
+        {
+            return $this->moduleKey;
+        }
+
+        public function name(): string
+        {
+            return ucfirst($this->moduleKey);
+        }
+
+        public function version(): string
+        {
+            return '1.0.0';
+        }
+
+        public function dependencies(): array
+        {
+            return $this->moduleDependencies;
+        }
+
+        public function isFoundational(): bool
+        {
+            return $this->moduleFoundational;
+        }
+    };
+}
+
+/**
+ * @param  array<int, ModuleInterface>  $modules
+ * @param  array<string, bool>  $state
+ */
+function makeManager(array $modules, array $state = [], bool $enabledByDefault = true, array $forcedDisabled = []): array
+{
+    $registry = new ModuleRegistry;
+
+    foreach ($modules as $module) {
+        $registry->register($module);
+    }
+
+    $manager = new ModuleManager(
+        registry: $registry,
+        state: new ArrayModuleStateRepository($state),
+        enabledByDefault: $enabledByDefault,
+        forcedDisabled: $forcedDisabled,
+    );
+
+    return [$manager, $registry];
+}
+
+it('reports unknown modules as disabled', function (): void {
+    [$manager] = makeManager([]);
+
+    expect($manager->isEnabled('ghost'))->toBeFalse();
+});
+
+it('always reports foundational modules as enabled regardless of stored state', function (): void {
+    [$manager] = makeManager([fakeModule('core', foundational: true)], ['core' => false]);
+
+    expect($manager->isEnabled('core'))->toBeTrue();
+});
+
+it('honours the enabled-by-default setting when no state is stored', function (): void {
+    [$onByDefault] = makeManager([fakeModule('blog')], enabledByDefault: true);
+    [$offByDefault] = makeManager([fakeModule('blog')], enabledByDefault: false);
+
+    expect($onByDefault->isEnabled('blog'))->toBeTrue()
+        ->and($offByDefault->isEnabled('blog'))->toBeFalse();
+});
+
+it('treats config force-disabled modules as disabled', function (): void {
+    [$manager] = makeManager([fakeModule('blog')], forcedDisabled: ['blog']);
+
+    expect($manager->isEnabled('blog'))->toBeFalse();
+});
+
+it('refuses to enable a module whose dependency is not registered', function (): void {
+    [$manager] = makeManager([fakeModule('posts', ['media'])]);
+
+    expect(fn () => $manager->enable('posts'))
+        ->toThrow(ModuleDependencyException::class);
+});
+
+it('refuses to enable a module whose dependency is disabled', function (): void {
+    [$manager] = makeManager(
+        [fakeModule('posts', ['media']), fakeModule('media')],
+        ['media' => false],
+    );
+
+    expect(fn () => $manager->enable('posts'))
+        ->toThrow(ModuleDependencyException::class);
+});
+
+it('enables a module when its dependencies are enabled', function (): void {
+    [$manager] = makeManager([fakeModule('posts', ['media']), fakeModule('media')]);
+
+    $manager->enable('posts');
+
+    expect($manager->isEnabled('posts'))->toBeTrue();
+});
+
+it('refuses to disable a foundational module', function (): void {
+    [$manager] = makeManager([fakeModule('core', foundational: true)]);
+
+    expect(fn () => $manager->disable('core'))
+        ->toThrow(ModuleDependencyException::class);
+});
+
+it('refuses to disable a module an enabled module depends on', function (): void {
+    [$manager] = makeManager([fakeModule('posts', ['media']), fakeModule('media')]);
+
+    expect(fn () => $manager->disable('media'))
+        ->toThrow(ModuleDependencyException::class);
+});
+
+it('disables a module once its dependents are disabled', function (): void {
+    [$manager] = makeManager(
+        [fakeModule('posts', ['media']), fakeModule('media')],
+        ['posts' => false],
+    );
+
+    $manager->disable('media');
+
+    expect($manager->isEnabled('media'))->toBeFalse();
+});
+
+it('orders boot so dependencies come before dependents', function (): void {
+    [$manager] = makeManager([
+        fakeModule('posts', ['media']),
+        fakeModule('media'),
+        fakeModule('seo', ['posts']),
+    ]);
+
+    $order = $manager->bootOrder();
+
+    expect(array_search('media', $order, true))->toBeLessThan(array_search('posts', $order, true))
+        ->and(array_search('posts', $order, true))->toBeLessThan(array_search('seo', $order, true));
+});
+
+it('excludes disabled modules from the boot order', function (): void {
+    [$manager] = makeManager(
+        [fakeModule('posts', ['media']), fakeModule('media')],
+        ['posts' => false],
+    );
+
+    expect($manager->bootOrder())->toBe(['media']);
+});
+
+it('resolves transitive dependencies', function (): void {
+    [$manager] = makeManager([
+        fakeModule('seo', ['posts']),
+        fakeModule('posts', ['media']),
+        fakeModule('media'),
+    ]);
+
+    expect($manager->dependenciesOf('seo'))->toContain('posts', 'media');
+});
+
+it('resolves transitive enabled dependents', function (): void {
+    [$manager] = makeManager([
+        fakeModule('seo', ['posts']),
+        fakeModule('posts', ['media']),
+        fakeModule('media'),
+    ]);
+
+    expect($manager->dependentsOf('media'))->toContain('posts', 'seo');
+});
+
+it('detects dependency cycles when computing boot order', function (): void {
+    [$manager] = makeManager([
+        fakeModule('a', ['b']),
+        fakeModule('b', ['a']),
+    ]);
+
+    expect(fn () => $manager->bootOrder())
+        ->toThrow(ModuleDependencyException::class);
+});

--- a/tests/Unit/Cms/ModuleRegistryTest.php
+++ b/tests/Unit/Cms/ModuleRegistryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Core\Module\ModuleRegistry;
+
+it('registers and resolves modules by key', function (): void {
+    $registry = new ModuleRegistry;
+    $module = fakeModule('pages');
+
+    $registry->register($module);
+
+    expect($registry->has('pages'))->toBeTrue()
+        ->and($registry->get('pages'))->toBe($module)
+        ->and($registry->all())->toHaveKey('pages');
+});
+
+it('returns null for unknown modules', function (): void {
+    expect((new ModuleRegistry)->get('ghost'))->toBeNull();
+});
+
+it('is idempotent so re-registration replaces rather than duplicates', function (): void {
+    $registry = new ModuleRegistry;
+
+    $registry->register(fakeModule('pages'));
+    $registry->register(fakeModule('pages'));
+
+    expect($registry->all())->toHaveCount(1);
+});


### PR DESCRIPTION
Establish the package-based, event-driven foundation for Liberu CMS: an open-source modular CMS that runs standalone, embedded, or headless.

Packages (hand-rolled under packages/liberu-cms/*, namespace Liberu\Cms\*, wired via a path repository so each is independently publishable):

- cms-contracts: interfaces, cross-module events, and the event-bus contract that everything depends on and that depends on nothing.
- cms-core: the kernel — module registry, lifecycle manager (dependency validation, cycle detection, topological boot ordering), database-backed module state with graceful pre-migration fallback, a self-gating base ModuleServiceProvider (a disabled module's provider stays registered but inert), a type-safe EventBus, and the `cms:make-module` generator.
- cms-hello: a proof-of-concept module exercising the full module contract (descriptor, own contract+service, event, versioned API route, migration, model, publishable config, README).

Guarantees enforced by tests:
- Removability: disabling a module leaves the app booting and its routes gone.
- Embeddability: core + a module boot inside a bare Laravel app and serve.
- Dependency direction: an architecture test fails CI on sideways/backward module imports.

Quality gates: 251 tests pass (38 new), PHPStan max (+Larastan) clean, Pint clean, Rector clean, Infection configured. New quality CI workflow. Docker dev env gains Meilisearch and the correct PHP 8.5 build arg.

Docs: docs/STACK.md (pinned versions + deviations) and docs/OPEN-QUESTIONS.md.