### PR TITLE
Phase 1: Identity & Access — cms-users authorization boundary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "liberu-cms/cms-contracts": "*",
         "liberu-cms/cms-core": "*",
         "liberu-cms/cms-hello": "*",
+        "liberu-cms/cms-users": "*",
         "livewire/livewire": "^4.0",
         "php": "^8.5",
         "spatie/laravel-passkeys": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "765c131cd66e6624b74ab6b892864934",
+    "content-hash": "8cfa43fbbc695dc7f876a8c889ab6a66",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5737,6 +5737,51 @@
                 "MIT"
             ],
             "description": "A trivial proof-of-concept Liberu CMS module that exercises the whole pipeline: descriptor, isolation, contract, service, event, route, migration, config, and tests.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-users",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-users",
+                "reference": "591f050a8589ed353ee9822f6c5c9b008740aec4"
+            },
+            "require": {
+                "illuminate/auth": "^13.0",
+                "illuminate/console": "^13.0",
+                "illuminate/contracts": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5",
+                "spatie/laravel-permission": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Users\\UsersServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Users\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Users\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Identity & Access for Liberu CMS: the authorization boundary and permission registry every other module depends on.",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/docs/OPEN-QUESTIONS.md
+++ b/docs/OPEN-QUESTIONS.md
@@ -11,11 +11,14 @@ work continues; revisit when the owning phase arrives.
    **Default:** leave installed for now. **Decision needed:** remove it (and the
    `Modules\` autoload + `app-modules/*` phpunit entry) to avoid two module systems.
 
-2. **Filament Shield vs. `spatie/laravel-permission`.** Both are installed and the
-   existing app uses Spatie's `permission_tables` migration plus a `Role` model.
-   **Default:** unchanged in Phase 0. **Decision needed (Phase 1):** the Users
-   module exposes one permission contract; decide which library backs it and keep
-   the other from leaking across module boundaries (Golden Rule 2).
+2. **Filament Shield vs. `spatie/laravel-permission`. — RESOLVED (Phase 1).**
+   They are layered, not competing: Spatie is the permission engine (stores
+   roles/permissions, wires the gate); Shield is the Filament admin UI and
+   policy/permission generator built on Spatie. The `cms-users` module exposes one
+   contract, `AccessControlInterface`, implemented over the framework **gate**
+   (which Spatie populates); Spatie is used only internally to materialise
+   permissions (Golden Rule 2d). An architecture test now forbids any CMS package
+   from importing the host `App\` namespace, so no module touches the users table.
 
 3. **Existing host-app CMS code.** `app/Models` and `app/Filament` already contain
    Page, Menu, Collection, Category, Tag, etc., violating Golden Rule 1 (feature

--- a/packages/liberu-cms/cms-contracts/src/Access/AccessControlInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Access/AccessControlInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Access;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * The single authorization boundary for the whole platform.
+ *
+ * Every module asks this contract "may the current user do X?" and never
+ * touches the users table, a role model, or the permission backend directly.
+ * The implementation lives in the Users module and is backed by the framework
+ * gate (which Shield/Spatie populate); swapping the backend changes nothing for
+ * consumers.
+ */
+interface AccessControlInterface
+{
+    /**
+     * Whether the currently authenticated user may perform the ability.
+     *
+     * Returns false when no user is authenticated.
+     *
+     * @param  mixed  $arguments  Optional target (e.g. a model) for policy checks.
+     */
+    public function can(string $ability, mixed $arguments = null): bool;
+
+    /**
+     * The inverse of can(): true when the ability is denied.
+     */
+    public function cannot(string $ability, mixed $arguments = null): bool;
+
+    /**
+     * Whether a specific user may perform the ability.
+     */
+    public function canForUser(Authenticatable $user, string $ability, mixed $arguments = null): bool;
+
+    /**
+     * Authorize the current user or throw.
+     *
+     * @throws AuthorizationException
+     */
+    public function authorize(string $ability, mixed $arguments = null): void;
+}

--- a/packages/liberu-cms/cms-contracts/src/Access/AccessScope.php
+++ b/packages/liberu-cms/cms-contracts/src/Access/AccessScope.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Access;
+
+/**
+ * The layer a permission governs, per Part B §7: content-, media-, and
+ * module-level permissions. Lets the platform group and reason about
+ * permissions by what they protect.
+ */
+enum AccessScope: string
+{
+    case Content = 'content';
+    case Media = 'media';
+    case Module = 'module';
+}

--- a/packages/liberu-cms/cms-contracts/src/Access/PermissionGroup.php
+++ b/packages/liberu-cms/cms-contracts/src/Access/PermissionGroup.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Access;
+
+/**
+ * A module's declaration of the permissions it owns.
+ *
+ * A module announces one or more groups (e.g. "pages" with abilities
+ * view/create/update/delete/publish) and the platform materialises the
+ * fully-qualified permission names (`pages.view`, …) into the permission
+ * backend. Consumers authorize against those names via AccessControlInterface.
+ */
+final readonly class PermissionGroup
+{
+    /**
+     * @param  string  $key  Machine key, e.g. "pages".
+     * @param  string  $label  Human label for admin surfaces.
+     * @param  array<int, string>  $abilities  Bare abilities, e.g. ["view", "publish"].
+     */
+    public function __construct(
+        public string $key,
+        public string $label,
+        public AccessScope $scope,
+        public array $abilities,
+    ) {}
+
+    /**
+     * Fully-qualified permission names, e.g. ["pages.view", "pages.publish"].
+     *
+     * @return array<int, string>
+     */
+    public function permissions(): array
+    {
+        return array_map(fn (string $ability): string => "{$this->key}.{$ability}", $this->abilities);
+    }
+}

--- a/packages/liberu-cms/cms-contracts/src/Access/PermissionRegistrarInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Access/PermissionRegistrarInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Access;
+
+/**
+ * The catalogue of permission groups declared by modules.
+ *
+ * Modules register their PermissionGroups during boot; the Users module reads
+ * the catalogue to materialise the permissions into the backend and to render
+ * them in admin surfaces. No module writes permissions directly.
+ */
+interface PermissionRegistrarInterface
+{
+    /**
+     * Declare a group of permissions owned by a module.
+     */
+    public function register(PermissionGroup $group): void;
+
+    /**
+     * All registered groups, keyed by group key.
+     *
+     * @return array<string, PermissionGroup>
+     */
+    public function groups(): array;
+
+    /**
+     * Every fully-qualified permission name across all groups.
+     *
+     * @return array<int, string>
+     */
+    public function permissions(): array;
+
+    /**
+     * Permission names limited to a single scope.
+     *
+     * @return array<int, string>
+     */
+    public function permissionsForScope(AccessScope $scope): array;
+}

--- a/packages/liberu-cms/cms-users/README.md
+++ b/packages/liberu-cms/cms-users/README.md
@@ -1,0 +1,60 @@
+# cms-users
+
+Identity & Access for Liberu CMS — the **single authorization boundary** every
+other module depends on. Foundational and non-removable.
+
+## The rule it enforces
+
+No module ever touches the users table, a role model, or the permission backend.
+Modules ask one contract, `AccessControlInterface`, "may the current user do X?".
+The implementation here answers via the framework gate, which the host's
+Shield/Spatie setup populates — so consumers stay decoupled from the backend and
+from any concrete `User`.
+
+## Public contracts (in `cms-contracts`)
+
+| Contract | Purpose |
+|----------|---------|
+| `AccessControlInterface` | `can` / `cannot` / `canForUser` / `authorize`. The authorization boundary. |
+| `PermissionRegistrarInterface` | Modules declare the permissions they own. |
+| `PermissionGroup` (DTO) | A module's permission set: key, label, `AccessScope`, abilities. |
+| `AccessScope` (enum) | `Content` · `Media` · `Module` (Part B §7). |
+
+## Usage from another module
+
+```php
+use Liberu\Cms\Contracts\Access\AccessControlInterface;
+
+if (app(AccessControlInterface::class)->can('pages.publish', $page)) {
+    // ...
+}
+
+// Declare your module's permissions (in your provider's boot):
+$registrar->register(new PermissionGroup('pages', 'Pages', AccessScope::Content, [
+    'view', 'create', 'update', 'delete', 'publish',
+]));
+```
+
+Then materialise them into the backend:
+
+```bash
+php artisan cms:sync-permissions
+```
+
+## Shield vs. Spatie — resolved
+
+They are layered, not competing: **Spatie** is the permission engine (stores
+roles/permissions, wires the gate), **Shield** is the Filament admin UI and
+policy/permission generator built on top of Spatie. This module wraps the
+**gate** for ability checks and uses **Spatie** only internally (Golden Rule 2d)
+to materialise permissions. Tenancy is inherited automatically: permission
+checks evaluate within the active team's context.
+
+## Events
+
+- **Emits / Listens:** none yet.
+
+## Extension points
+
+- Register `PermissionGroup`s via `PermissionRegistrarInterface`.
+- Swap the backend by rebinding `AccessControlInterface`.

--- a/packages/liberu-cms/cms-users/composer.json
+++ b/packages/liberu-cms/cms-users/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "liberu-cms/cms-users",
+    "description": "Identity & Access for Liberu CMS: the authorization boundary and permission registry every other module depends on.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "illuminate/auth": "^13.0",
+        "illuminate/console": "^13.0",
+        "illuminate/contracts": "^13.0",
+        "illuminate/support": "^13.0",
+        "spatie/laravel-permission": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Users\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Users\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Users\\UsersServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-users/config/users.php
+++ b/packages/liberu-cms/cms-users/config/users.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization guard
+    |--------------------------------------------------------------------------
+    |
+    | The guard whose gate the access-control boundary evaluates against, and
+    | under which synced permissions are created.
+    |
+    */
+
+    'guard' => 'web',
+
+];

--- a/packages/liberu-cms/cms-users/src/Access/AccessControl.php
+++ b/packages/liberu-cms/cms-users/src/Access/AccessControl.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users\Access;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Liberu\Cms\Contracts\Access\AccessControlInterface;
+
+/**
+ * The authorization boundary, implemented over the framework gate.
+ *
+ * The gate is populated by the host's permission backend (Shield/Spatie), so
+ * this class stays free of any concrete user, role, or permission class. Team
+ * scoping is inherited automatically: the backend evaluates permissions within
+ * the active tenant's context.
+ */
+final readonly class AccessControl implements AccessControlInterface
+{
+    public function __construct(
+        private AuthFactory $auth,
+        private Gate $gate,
+    ) {}
+
+    public function can(string $ability, mixed $arguments = null): bool
+    {
+        $user = $this->auth->guard()->user();
+
+        return $user !== null && $this->canForUser($user, $ability, $arguments);
+    }
+
+    public function cannot(string $ability, mixed $arguments = null): bool
+    {
+        return ! $this->can($ability, $arguments);
+    }
+
+    public function canForUser(Authenticatable $user, string $ability, mixed $arguments = null): bool
+    {
+        return $this->gate->forUser($user)->allows($ability, $arguments ?? []);
+    }
+
+    public function authorize(string $ability, mixed $arguments = null): void
+    {
+        if ($this->cannot($ability, $arguments)) {
+            throw new AuthorizationException('This action is unauthorized.');
+        }
+    }
+}

--- a/packages/liberu-cms/cms-users/src/Access/PermissionRegistrar.php
+++ b/packages/liberu-cms/cms-users/src/Access/PermissionRegistrar.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users\Access;
+
+use Liberu\Cms\Contracts\Access\AccessScope;
+use Liberu\Cms\Contracts\Access\PermissionGroup;
+use Liberu\Cms\Contracts\Access\PermissionRegistrarInterface;
+
+/**
+ * In-memory catalogue of every permission group modules declare. Registration
+ * is idempotent per group key so re-declaring is safe.
+ */
+final class PermissionRegistrar implements PermissionRegistrarInterface
+{
+    /**
+     * @var array<string, PermissionGroup>
+     */
+    private array $groups = [];
+
+    public function register(PermissionGroup $group): void
+    {
+        $this->groups[$group->key] = $group;
+    }
+
+    public function groups(): array
+    {
+        return $this->groups;
+    }
+
+    public function permissions(): array
+    {
+        return $this->collect(fn (PermissionGroup $group): bool => true);
+    }
+
+    public function permissionsForScope(AccessScope $scope): array
+    {
+        return $this->collect(fn (PermissionGroup $group): bool => $group->scope === $scope);
+    }
+
+    /**
+     * @param  callable(PermissionGroup): bool  $filter
+     * @return array<int, string>
+     */
+    private function collect(callable $filter): array
+    {
+        $names = [];
+
+        foreach ($this->groups as $group) {
+            if ($filter($group)) {
+                array_push($names, ...$group->permissions());
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+}

--- a/packages/liberu-cms/cms-users/src/Access/SyncPermissions.php
+++ b/packages/liberu-cms/cms-users/src/Access/SyncPermissions.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users\Access;
+
+use Liberu\Cms\Contracts\Access\PermissionRegistrarInterface;
+use Spatie\Permission\Models\Permission;
+
+/**
+ * Materialises every module-declared permission into the Spatie backend.
+ *
+ * Spatie is an internal implementation detail of the Users module (Golden Rule
+ * 2d); no other module references it. Idempotent via findOrCreate.
+ */
+final readonly class SyncPermissions
+{
+    public function __construct(
+        private PermissionRegistrarInterface $registrar,
+        private string $guard = 'web',
+    ) {}
+
+    /**
+     * @return array<int, string> The permission names that now exist.
+     */
+    public function __invoke(): array
+    {
+        $names = $this->registrar->permissions();
+
+        foreach ($names as $name) {
+            Permission::findOrCreate($name, $this->guard);
+        }
+
+        return $names;
+    }
+}

--- a/packages/liberu-cms/cms-users/src/Console/SyncPermissionsCommand.php
+++ b/packages/liberu-cms/cms-users/src/Console/SyncPermissionsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users\Console;
+
+use Illuminate\Console\Command;
+use Liberu\Cms\Users\Access\SyncPermissions;
+
+final class SyncPermissionsCommand extends Command
+{
+    #[\Override]
+    protected $signature = 'cms:sync-permissions';
+
+    #[\Override]
+    protected $description = 'Materialise all module-declared CMS permissions into the permission backend';
+
+    public function handle(SyncPermissions $sync): int
+    {
+        $names = $sync();
+
+        $this->components->info(sprintf('Synced %d CMS permission(s).', count($names)));
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/liberu-cms/cms-users/src/UsersModule.php
+++ b/packages/liberu-cms/cms-users/src/UsersModule.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Identity & Access. Foundational: everything downstream authorizes against it,
+ * so it cannot be disabled through the module manager.
+ */
+final class UsersModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'users';
+    }
+
+    public function name(): string
+    {
+        return 'Users & Access';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+
+    #[\Override]
+    public function isFoundational(): bool
+    {
+        return true;
+    }
+}

--- a/packages/liberu-cms/cms-users/src/UsersServiceProvider.php
+++ b/packages/liberu-cms/cms-users/src/UsersServiceProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Users;
+
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Liberu\Cms\Contracts\Access\AccessControlInterface;
+use Liberu\Cms\Contracts\Access\AccessScope;
+use Liberu\Cms\Contracts\Access\PermissionGroup;
+use Liberu\Cms\Contracts\Access\PermissionRegistrarInterface;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+use Liberu\Cms\Users\Access\AccessControl;
+use Liberu\Cms\Users\Access\PermissionRegistrar;
+use Liberu\Cms\Users\Access\SyncPermissions;
+use Liberu\Cms\Users\Console\SyncPermissionsCommand;
+
+final class UsersServiceProvider extends ModuleServiceProvider
+{
+    public function module(): ModuleInterface
+    {
+        return new UsersModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/users.php', 'cms-users');
+
+        $this->app->singleton(PermissionRegistrarInterface::class, PermissionRegistrar::class);
+
+        $this->app->singleton(AccessControlInterface::class, fn (): AccessControl => new AccessControl(
+            $this->app->make(AuthFactory::class),
+            $this->app->make(Gate::class),
+        ));
+
+        $this->app->bind(SyncPermissions::class, fn (): SyncPermissions => new SyncPermissions(
+            $this->app->make(PermissionRegistrarInterface::class),
+            $this->guard(),
+        ));
+    }
+
+    protected function bootModule(): void
+    {
+        $this->declarePermissions($this->app->make(PermissionRegistrarInterface::class));
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/users.php' => $this->app->configPath('cms-users.php'),
+            ], 'cms-users-config');
+
+            $this->commands([SyncPermissionsCommand::class]);
+        }
+    }
+
+    private function declarePermissions(PermissionRegistrarInterface $registrar): void
+    {
+        $registrar->register(new PermissionGroup('users', 'Users', AccessScope::Module, [
+            'view', 'create', 'update', 'delete',
+        ]));
+
+        $registrar->register(new PermissionGroup('roles', 'Roles', AccessScope::Module, [
+            'view', 'create', 'update', 'delete', 'assign',
+        ]));
+    }
+
+    private function guard(): string
+    {
+        $guard = config('cms-users.guard', 'web');
+
+        return is_string($guard) ? $guard : 'web';
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,5 @@ parameters:
         - packages/liberu-cms/cms-contracts/src
         - packages/liberu-cms/cms-core/src
         - packages/liberu-cms/cms-hello/src
+        - packages/liberu-cms/cms-users/src
     treatPhpDocTypesAsCertain: false

--- a/tests/Feature/Cms/AccessControlTest.php
+++ b/tests/Feature/Cms/AccessControlTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Contracts\Access\AccessControlInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Core\Exceptions\ModuleDependencyException;
+use Liberu\Cms\Users\Access\AccessControl;
+use Liberu\Cms\Users\Access\SyncPermissions;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Create a user whose single role grants exactly the given permissions, within
+ * their own team's context, and act as them. Avoids the super_admin role so no
+ * gate bypass masks the check.
+ *
+ * @param  array<int, string>  $permissions
+ */
+function actingUserGranted(array $permissions): User
+{
+    $user = User::factory()->create();
+    $team = $user->createPersonalTeam();
+    setPermissionsTeamId($team->id);
+
+    app(SyncPermissions::class)();
+
+    $role = Role::create(['name' => 'scoped-role', 'team_id' => $team->id, 'guard_name' => 'web']);
+    $role->givePermissionTo($permissions);
+    $user->syncRoles([$role]);
+
+    test()->actingAs($user);
+    setPermissionsTeamId($team->id);
+
+    return $user;
+}
+
+it('resolves the access-control contract from the container', function (): void {
+    expect(app(AccessControlInterface::class))->toBeInstanceOf(AccessControl::class);
+});
+
+it('grants an ability the user\'s role includes', function (): void {
+    actingUserGranted(['users.view']);
+
+    expect(app(AccessControlInterface::class)->can('users.view'))->toBeTrue();
+});
+
+it('denies an ability the user\'s role does not include', function (): void {
+    actingUserGranted(['users.view']);
+
+    $access = app(AccessControlInterface::class);
+
+    expect($access->can('users.delete'))->toBeFalse()
+        ->and($access->cannot('users.delete'))->toBeTrue();
+});
+
+it('denies everything when no user is authenticated', function (): void {
+    expect(app(AccessControlInterface::class)->can('users.view'))->toBeFalse();
+});
+
+it('checks a specific user via canForUser', function (): void {
+    $user = actingUserGranted(['users.view']);
+    auth()->logout();
+
+    $access = app(AccessControlInterface::class);
+
+    expect($access->canForUser($user, 'users.view'))->toBeTrue()
+        ->and($access->canForUser($user, 'users.delete'))->toBeFalse();
+});
+
+it('throws when authorizing a denied ability', function (): void {
+    actingUserGranted(['users.view']);
+
+    expect(fn () => app(AccessControlInterface::class)->authorize('users.delete'))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('does not throw when authorizing a granted ability', function (): void {
+    actingUserGranted(['users.view']);
+
+    app(AccessControlInterface::class)->authorize('users.view');
+})->throwsNoExceptions();
+
+it('keeps the Users module foundational so it cannot be disabled', function (): void {
+    expect(fn () => app(ModuleManagerInterface::class)->disable('users'))
+        ->toThrow(ModuleDependencyException::class);
+});

--- a/tests/Feature/Cms/ArchitectureTest.php
+++ b/tests/Feature/Cms/ArchitectureTest.php
@@ -86,7 +86,32 @@ it('keeps module dependencies pointing only inward (no sideways or backward impo
     expect($violations)->toBe([]);
 });
 
-it('discovers the three foundational Phase 0 packages', function (): void {
+it('never lets a module reach into the host application namespace', function (): void {
+    $violations = [];
+
+    foreach (cmsPackageNamespaces() as $package) {
+        $src = base_path("packages/liberu-cms/{$package}/src");
+
+        if (! is_dir($src)) {
+            continue;
+        }
+
+        foreach (Finder::create()->files()->in($src)->name('*.php') as $file) {
+            if (preg_match('/^\s*use\s+App\\\\/m', (string) file_get_contents($file->getRealPath()))) {
+                $violations[] = "{$package} imports the host App\\ namespace";
+            }
+        }
+    }
+
+    expect($violations)->toBe([]);
+});
+
+it('discovers the foundational CMS packages', function (): void {
     expect(cmsPackageNamespaces())
-        ->toHaveKeys(['Liberu\Cms\Contracts', 'Liberu\Cms\Core', 'Liberu\Cms\Hello']);
+        ->toHaveKeys([
+            'Liberu\Cms\Contracts',
+            'Liberu\Cms\Core',
+            'Liberu\Cms\Hello',
+            'Liberu\Cms\Users',
+        ]);
 });

--- a/tests/Unit/Cms/PermissionRegistrarTest.php
+++ b/tests/Unit/Cms/PermissionRegistrarTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Liberu\Cms\Contracts\Access\AccessScope;
+use Liberu\Cms\Contracts\Access\PermissionGroup;
+use Liberu\Cms\Users\Access\PermissionRegistrar;
+
+it('builds fully-qualified permission names from a group', function (): void {
+    $group = new PermissionGroup('pages', 'Pages', AccessScope::Content, ['view', 'publish']);
+
+    expect($group->permissions())->toBe(['pages.view', 'pages.publish']);
+});
+
+it('collects and de-duplicates permissions across groups', function (): void {
+    $registrar = new PermissionRegistrar;
+    $registrar->register(new PermissionGroup('pages', 'Pages', AccessScope::Content, ['view']));
+    $registrar->register(new PermissionGroup('media', 'Media', AccessScope::Media, ['view']));
+
+    expect($registrar->permissions())->toBe(['pages.view', 'media.view']);
+});
+
+it('filters permissions by scope', function (): void {
+    $registrar = new PermissionRegistrar;
+    $registrar->register(new PermissionGroup('pages', 'Pages', AccessScope::Content, ['view']));
+    $registrar->register(new PermissionGroup('media', 'Media', AccessScope::Media, ['view']));
+
+    expect($registrar->permissionsForScope(AccessScope::Content))->toBe(['pages.view'])
+        ->and($registrar->permissionsForScope(AccessScope::Media))->toBe(['media.view']);
+});
+
+it('is idempotent per group key so re-declaring replaces', function (): void {
+    $registrar = new PermissionRegistrar;
+    $registrar->register(new PermissionGroup('pages', 'Pages', AccessScope::Content, ['view']));
+    $registrar->register(new PermissionGroup('pages', 'Pages', AccessScope::Content, ['view', 'publish']));
+
+    expect($registrar->groups())->toHaveCount(1)
+        ->and($registrar->permissions())->toBe(['pages.view', 'pages.publish']);
+});


### PR DESCRIPTION
Add the module every downstream feature authorizes against, as an independently installable package. Foundational: it cannot be disabled.

Contracts (cms-contracts):
- AccessControlInterface — can / cannot / canForUser / authorize. The single authorization boundary; no module touches the users table, a role model, or the permission backend directly.
- PermissionRegistrarInterface + PermissionGroup DTO + AccessScope enum (Content / Media / Module, per Part B §7) — modules declare the permissions they own.

cms-users module:
- AccessControl implemented over the framework gate (which the host's Shield/Spatie setup populates), so consumers stay decoupled from the backend and from any concrete User. Tenancy is inherited: checks evaluate within the active team.
- PermissionRegistrar collects declarations; SyncPermissions + `cms:sync-permissions` materialise them into the backend (Spatie used only internally — Golden Rule 2d).
- Declares its own module-level permissions (users.*, roles.*).

Shield vs Spatie — resolved: they are layered (Spatie = engine, Shield = admin UI built on it), both behind AccessControlInterface. Documented in OPEN-QUESTIONS.

Tests (271 total green):
- Authorization + role-restriction through the contract, canForUser, authorize throwing, unauthenticated denial, container resolution, foundational guarantee.
- Permission registrar/DTO unit tests.
- Architecture test extended: no CMS package may import the host App\ namespace, enforcing "modules never touch the users table directly".

PHPStan max clean (cms-users added to analysis), Pint clean, Rector clean.