### PR TITLE
Phase 2 (1/n): cms-media — media library behind a content-agnostic co…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "liberu-cms/cms-contracts": "*",
         "liberu-cms/cms-core": "*",
         "liberu-cms/cms-hello": "*",
+        "liberu-cms/cms-media": "*",
         "liberu-cms/cms-users": "*",
         "livewire/livewire": "^4.0",
         "php": "^8.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cfa43fbbc695dc7f876a8c889ab6a66",
+    "content-hash": "246e853b1986a864d6f105e0e1cbbc9e",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5737,6 +5737,51 @@
                 "MIT"
             ],
             "description": "A trivial proof-of-concept Liberu CMS module that exercises the whole pipeline: descriptor, isolation, contract, service, event, route, migration, config, and tests.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-media",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-media",
+                "reference": "dc3a36b68238c26f2c2f6f7567dad6e54018cf3e"
+            },
+            "require": {
+                "illuminate/contracts": "^13.0",
+                "illuminate/database": "^13.0",
+                "illuminate/filesystem": "^13.0",
+                "illuminate/http": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Media\\MediaServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Media\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Media\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Media library for Liberu CMS: secure uploads, storage, folders, and metadata behind a content-agnostic contract.",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/packages/liberu-cms/cms-contracts/src/Events/Media/MediaUploaded.php
+++ b/packages/liberu-cms/cms-contracts/src/Events/Media/MediaUploaded.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Events\Media;
+
+use Liberu\Cms\Contracts\Events\CmsEvent;
+use Liberu\Cms\Contracts\Media\MediaItemInterface;
+
+/**
+ * Emitted when a file has been stored in the media library. Image processing,
+ * search indexing, and CDN warmers listen for this without importing the Media
+ * module's internals.
+ */
+final readonly class MediaUploaded implements CmsEvent
+{
+    public function __construct(public MediaItemInterface $media) {}
+
+    public function name(): string
+    {
+        return 'media.uploaded';
+    }
+}

--- a/packages/liberu-cms/cms-contracts/src/Media/MediaItemInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Media/MediaItemInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Media;
+
+/**
+ * A stored media item, exposed to other modules as a read-only value.
+ *
+ * Content modules reference media by key and resolve the item through the
+ * MediaRepository; they never touch the media model, disk, or storage backend.
+ */
+interface MediaItemInterface
+{
+    /**
+     * The media item's stable identifier.
+     */
+    public function mediaId(): int|string;
+
+    /**
+     * The filesystem disk the file lives on.
+     */
+    public function disk(): string;
+
+    /**
+     * The path to the file on its disk.
+     */
+    public function path(): string;
+
+    /**
+     * A publicly resolvable URL for the file.
+     */
+    public function url(): string;
+
+    /**
+     * The original, human-readable file name.
+     */
+    public function fileName(): string;
+
+    public function mimeType(): string;
+
+    /**
+     * Size in bytes.
+     */
+    public function size(): int;
+
+    /**
+     * The folder the item is organised under, or null for the root.
+     */
+    public function folder(): ?string;
+
+    /**
+     * Arbitrary stored metadata (dimensions, alt text, tags, …).
+     *
+     * @return array<string, mixed>
+     */
+    public function metadata(): array;
+}

--- a/packages/liberu-cms/cms-contracts/src/Media/MediaRepositoryInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Media/MediaRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Media;
+
+/**
+ * The read/lifecycle boundary other modules use to work with media.
+ *
+ * Uploading (which involves framework request types) is a Media-module concern;
+ * consumers only need to resolve, list, and detach media by key.
+ */
+interface MediaRepositoryInterface
+{
+    /**
+     * Resolve a media item by key, or null when it does not exist.
+     */
+    public function find(int|string $id): ?MediaItemInterface;
+
+    /**
+     * All media items in a folder (null = the root folder).
+     *
+     * @return iterable<int, MediaItemInterface>
+     */
+    public function inFolder(?string $folder = null): iterable;
+
+    /**
+     * Permanently remove a media item and its underlying file.
+     */
+    public function delete(int|string $id): bool;
+}

--- a/packages/liberu-cms/cms-media/README.md
+++ b/packages/liberu-cms/cms-media/README.md
@@ -1,0 +1,49 @@
+# cms-media
+
+The media library for Liberu CMS: secure uploads, storage, folders, and
+metadata, exposed to the rest of the platform behind a content-agnostic contract.
+
+## Public contracts (in `cms-contracts`)
+
+| Contract | Purpose |
+|----------|---------|
+| `MediaRepositoryInterface` | `find` / `inFolder` / `delete`. How other modules resolve and manage media by key. |
+| `MediaItemInterface` | A read-only media value: disk, path, url, file name, mime type, size, folder, metadata. |
+| `MediaUploaded` (event) | Broadcast after a file is stored — for image processing, indexing, CDN warmers. |
+
+Content modules store a media **key** and resolve it through the repository; they
+never touch the media model, disk, or storage backend.
+
+## Uploading
+
+`StoreUpload` (a module service) validates and stores an `UploadedFile`:
+
+```php
+$media = app(\Liberu\Cms\Media\Media\StoreUpload::class)($request->file('file'), folder: 'articles');
+$media->url();
+```
+
+- **Secure by default (OWASP A08):** MIME type is derived from file *contents*
+  (not the client's claim) and checked against an allow-list; size is bounded.
+  Violations throw `InvalidUpload`.
+- Image uploads capture `width`/`height` metadata automatically.
+
+## Config (`config/cms-media.php`)
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `disk` | `public` | Storage disk for uploads. |
+| `max_size_kb` | `20480` | Maximum upload size. |
+| `allowed_mime_types` | image/video/audio/doc set | Accepted content types. |
+
+## Events
+
+- **Emits:** `Liberu\Cms\Contracts\Events\Media\MediaUploaded`.
+- **Listens:** none.
+
+## Extension points / roadmap
+
+- **Image processing** (resize, thumbnails, WebP): a `MediaUploaded` listener is
+  the intended seam. Full processing needs an imaging library
+  (e.g. `intervention/image`) — a dependency to add with approval.
+- **CDN / remote disks** (S3, R2, Spaces): configure the `disk`.

--- a/packages/liberu-cms/cms-media/composer.json
+++ b/packages/liberu-cms/cms-media/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "liberu-cms/cms-media",
+    "description": "Media library for Liberu CMS: secure uploads, storage, folders, and metadata behind a content-agnostic contract.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "illuminate/contracts": "^13.0",
+        "illuminate/database": "^13.0",
+        "illuminate/filesystem": "^13.0",
+        "illuminate/http": "^13.0",
+        "illuminate/support": "^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Media\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Media\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Media\\MediaServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-media/config/media.php
+++ b/packages/liberu-cms/cms-media/config/media.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage disk
+    |--------------------------------------------------------------------------
+    |
+    | The filesystem disk uploaded media is stored on.
+    |
+    */
+
+    'disk' => 'public',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Upload constraints (secure uploads — OWASP A08)
+    |--------------------------------------------------------------------------
+    |
+    | Maximum size in kilobytes and the MIME types accepted. Anything outside
+    | these bounds is rejected before it is stored.
+    |
+    */
+
+    'max_size_kb' => 20480,
+
+    'allowed_mime_types' => [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+        'video/mp4',
+        'audio/mpeg',
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+
+];

--- a/packages/liberu-cms/cms-media/database/migrations/2026_01_02_000000_create_cms_media_table.php
+++ b/packages/liberu-cms/cms-media/database/migrations/2026_01_02_000000_create_cms_media_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cms_media', function (Blueprint $table): void {
+            $table->id();
+            $table->string('disk');
+            $table->string('path');
+            $table->string('file_name');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size');
+            $table->string('folder')->nullable()->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_media');
+    }
+};

--- a/packages/liberu-cms/cms-media/src/Exceptions/InvalidUpload.php
+++ b/packages/liberu-cms/cms-media/src/Exceptions/InvalidUpload.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media\Exceptions;
+
+use RuntimeException;
+
+final class InvalidUpload extends RuntimeException
+{
+    public static function corrupt(): self
+    {
+        return new self('The uploaded file is invalid or could not be stored.');
+    }
+
+    public static function tooLarge(int $sizeKb, int $maxKb): self
+    {
+        return new self("The file is {$sizeKb} KB, which exceeds the {$maxKb} KB limit.");
+    }
+
+    public static function disallowedType(string $mimeType): self
+    {
+        return new self("Files of type [{$mimeType}] are not allowed.");
+    }
+}

--- a/packages/liberu-cms/cms-media/src/Media/MediaRepository.php
+++ b/packages/liberu-cms/cms-media/src/Media/MediaRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media\Media;
+
+use Illuminate\Support\Facades\Storage;
+use Liberu\Cms\Contracts\Media\MediaItemInterface;
+use Liberu\Cms\Contracts\Media\MediaRepositoryInterface;
+use Liberu\Cms\Media\Models\Media;
+
+final class MediaRepository implements MediaRepositoryInterface
+{
+    public function find(int|string $id): ?MediaItemInterface
+    {
+        return Media::query()->find($id);
+    }
+
+    public function inFolder(?string $folder = null): iterable
+    {
+        return Media::query()
+            ->where('folder', $folder)
+            ->orderBy('file_name')
+            ->get()
+            ->all();
+    }
+
+    public function delete(int|string $id): bool
+    {
+        $media = Media::query()->find($id);
+
+        if ($media === null) {
+            return false;
+        }
+
+        Storage::disk($media->disk)->delete($media->path);
+
+        return (bool) $media->delete();
+    }
+}

--- a/packages/liberu-cms/cms-media/src/Media/StoreUpload.php
+++ b/packages/liberu-cms/cms-media/src/Media/StoreUpload.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media\Media;
+
+use Illuminate\Http\UploadedFile;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Events\Media\MediaUploaded;
+use Liberu\Cms\Contracts\Media\MediaItemInterface;
+use Liberu\Cms\Media\Exceptions\InvalidUpload;
+use Liberu\Cms\Media\Models\Media;
+
+/**
+ * Validates and stores an uploaded file into the media library.
+ *
+ * MIME type is derived from the file's contents (not the client's claim) and
+ * checked against an allow-list, and size is bounded — secure uploads per
+ * OWASP A08. On success a MediaUploaded event is broadcast for listeners such
+ * as image processing or search indexing.
+ */
+final readonly class StoreUpload
+{
+    /**
+     * @param  array<int, string>  $allowedMimeTypes
+     */
+    public function __construct(
+        private EventBusInterface $events,
+        private string $disk,
+        private int $maxSizeKb,
+        private array $allowedMimeTypes,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __invoke(UploadedFile $file, ?string $folder = null, array $metadata = []): MediaItemInterface
+    {
+        $this->validate($file);
+
+        $path = $file->store($folder ?? 'media', $this->disk);
+
+        if ($path === false) {
+            throw InvalidUpload::corrupt();
+        }
+
+        $media = Media::create([
+            'disk' => $this->disk,
+            'path' => $path,
+            'file_name' => $file->getClientOriginalName(),
+            'mime_type' => $this->mimeType($file),
+            'size' => (int) $file->getSize(),
+            'folder' => $folder,
+            'metadata' => array_merge($this->extractMetadata($file), $metadata),
+        ]);
+
+        $this->events->dispatch(new MediaUploaded($media));
+
+        return $media;
+    }
+
+    private function validate(UploadedFile $file): void
+    {
+        if (! $file->isValid()) {
+            throw InvalidUpload::corrupt();
+        }
+
+        $sizeKb = (int) ceil((int) $file->getSize() / 1024);
+
+        if ($sizeKb > $this->maxSizeKb) {
+            throw InvalidUpload::tooLarge($sizeKb, $this->maxSizeKb);
+        }
+
+        $mimeType = $this->mimeType($file);
+
+        if (! in_array($mimeType, $this->allowedMimeTypes, true)) {
+            throw InvalidUpload::disallowedType($mimeType);
+        }
+    }
+
+    private function mimeType(UploadedFile $file): string
+    {
+        return $file->getMimeType() ?? $file->getClientMimeType();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractMetadata(UploadedFile $file): array
+    {
+        if (! str_starts_with($this->mimeType($file), 'image/')) {
+            return [];
+        }
+
+        $path = $file->getRealPath();
+
+        if ($path === false) {
+            return [];
+        }
+
+        $dimensions = @getimagesize($path);
+
+        if ($dimensions === false) {
+            return [];
+        }
+
+        return ['width' => $dimensions[0], 'height' => $dimensions[1]];
+    }
+}

--- a/packages/liberu-cms/cms-media/src/MediaModule.php
+++ b/packages/liberu-cms/cms-media/src/MediaModule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Media library. A dependency of the content modules; not foundational —
+ * content modules declare it as a dependency, so it cannot be disabled out from
+ * under them, but a media-less install may remove it.
+ */
+final class MediaModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'media';
+    }
+
+    public function name(): string
+    {
+        return 'Media';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-media/src/MediaServiceProvider.php
+++ b/packages/liberu-cms/cms-media/src/MediaServiceProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Media\MediaRepositoryInterface;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+use Liberu\Cms\Media\Media\MediaRepository;
+use Liberu\Cms\Media\Media\StoreUpload;
+
+final class MediaServiceProvider extends ModuleServiceProvider
+{
+    public function module(): ModuleInterface
+    {
+        return new MediaModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/media.php', 'cms-media');
+
+        $this->app->singleton(MediaRepositoryInterface::class, MediaRepository::class);
+
+        $this->app->bind(StoreUpload::class, function (): StoreUpload {
+            $config = $this->app->make(ConfigRepository::class);
+
+            $disk = $config->get('cms-media.disk');
+            $maxSize = $config->get('cms-media.max_size_kb');
+            $mimeTypes = $config->get('cms-media.allowed_mime_types');
+
+            return new StoreUpload(
+                $this->app->make(EventBusInterface::class),
+                is_string($disk) ? $disk : 'public',
+                is_int($maxSize) ? $maxSize : 20480,
+                is_array($mimeTypes) ? array_values(array_filter($mimeTypes, is_string(...))) : [],
+            );
+        });
+    }
+
+    protected function bootModule(): void
+    {
+        $this->loadModuleMigrations(__DIR__.'/../database/migrations');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/media.php' => $this->app->configPath('cms-media.php'),
+            ], 'cms-media-config');
+        }
+    }
+}

--- a/packages/liberu-cms/cms-media/src/Models/Media.php
+++ b/packages/liberu-cms/cms-media/src/Models/Media.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Media\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Liberu\Cms\Contracts\Media\MediaItemInterface;
+
+/**
+ * @property int $id
+ * @property string $disk
+ * @property string $path
+ * @property string $file_name
+ * @property string $mime_type
+ * @property int $size
+ * @property string|null $folder
+ * @property array<string, mixed>|null $metadata
+ */
+final class Media extends Model implements MediaItemInterface
+{
+    #[\Override]
+    protected $table = 'cms_media';
+
+    /**
+     * @var list<string>
+     */
+    #[\Override]
+    protected $fillable = [
+        'disk',
+        'path',
+        'file_name',
+        'mime_type',
+        'size',
+        'folder',
+        'metadata',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'size' => 'integer',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function mediaId(): int
+    {
+        return $this->id;
+    }
+
+    public function disk(): string
+    {
+        return $this->disk;
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function url(): string
+    {
+        return Storage::disk($this->disk)->url($this->path);
+    }
+
+    public function fileName(): string
+    {
+        return $this->file_name;
+    }
+
+    public function mimeType(): string
+    {
+        return $this->mime_type;
+    }
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+
+    public function folder(): ?string
+    {
+        return $this->folder;
+    }
+
+    public function metadata(): array
+    {
+        return $this->metadata ?? [];
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,6 @@ parameters:
         - packages/liberu-cms/cms-contracts/src
         - packages/liberu-cms/cms-core/src
         - packages/liberu-cms/cms-hello/src
+        - packages/liberu-cms/cms-media/src
         - packages/liberu-cms/cms-users/src
     treatPhpDocTypesAsCertain: false

--- a/tests/Feature/Cms/MediaUploadTest.php
+++ b/tests/Feature/Cms/MediaUploadTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Liberu\Cms\Contracts\Events\Media\MediaUploaded;
+use Liberu\Cms\Contracts\Media\MediaRepositoryInterface;
+use Liberu\Cms\Media\Exceptions\InvalidUpload;
+use Liberu\Cms\Media\Media\StoreUpload;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Storage::fake('public');
+});
+
+it('stores a valid image, captures dimensions, and persists a record', function (): void {
+    $media = app(StoreUpload::class)(UploadedFile::fake()->image('photo.jpg', 120, 80), 'articles');
+
+    Storage::disk('public')->assertExists($media->path());
+
+    expect($media->fileName())->toBe('photo.jpg')
+        ->and($media->folder())->toBe('articles')
+        ->and($media->mimeType())->toBe('image/jpeg')
+        ->and($media->metadata())->toMatchArray(['width' => 120, 'height' => 80]);
+
+    $this->assertDatabaseHas('cms_media', ['file_name' => 'photo.jpg', 'folder' => 'articles']);
+});
+
+it('broadcasts MediaUploaded after a successful upload', function (): void {
+    Event::fake([MediaUploaded::class]);
+
+    app(StoreUpload::class)(UploadedFile::fake()->image('banner.png'));
+
+    Event::assertDispatched(MediaUploaded::class);
+});
+
+it('rejects a disallowed file type', function (): void {
+    expect(fn () => app(StoreUpload::class)(UploadedFile::fake()->create('script.php', 8, 'application/x-php')))
+        ->toThrow(InvalidUpload::class);
+
+    expect(Storage::disk('public')->allFiles())->toBe([]);
+});
+
+it('rejects a file that exceeds the size limit', function (): void {
+    config(['cms-media.max_size_kb' => 100]);
+
+    expect(fn () => app(StoreUpload::class)(UploadedFile::fake()->create('huge.pdf', 500, 'application/pdf')))
+        ->toThrow(InvalidUpload::class);
+});
+
+it('finds media and lists it by folder through the repository', function (): void {
+    $a = app(StoreUpload::class)(UploadedFile::fake()->image('a.jpg'), 'gallery');
+    app(StoreUpload::class)(UploadedFile::fake()->image('b.jpg'), 'other');
+
+    $repository = app(MediaRepositoryInterface::class);
+
+    expect($repository->find($a->mediaId())?->fileName())->toBe('a.jpg')
+        ->and($repository->inFolder('gallery'))->toHaveCount(1)
+        ->and($repository->inFolder('other'))->toHaveCount(1);
+});
+
+it('deletes a media item and its underlying file', function (): void {
+    $media = app(StoreUpload::class)(UploadedFile::fake()->image('gone.jpg'));
+    $repository = app(MediaRepositoryInterface::class);
+
+    Storage::disk('public')->assertExists($media->path());
+
+    expect($repository->delete($media->mediaId()))->toBeTrue();
+
+    Storage::disk('public')->assertMissing($media->path());
+    expect($repository->find($media->mediaId()))->toBeNull();
+});


### PR DESCRIPTION
…ntract

First Content Core increment. Media is a dependency of the content modules, so it lands first.

Contracts (cms-contracts):
- MediaRepositoryInterface (find / inFolder / delete) and MediaItemInterface — the read/lifecycle boundary content modules use to reference media by key without touching the media model, disk, or storage backend.
- MediaUploaded event for listeners (image processing, indexing, CDN).

cms-media module:
- Media model + cms_media migration (disk, path, file_name, mime_type, size, folder, metadata).
- MediaRepository over the filesystem; StoreUpload service with secure-by-default validation — MIME derived from file contents (not the client's claim) and allow-listed, size bounded (OWASP A08) — capturing image dimensions and broadcasting MediaUploaded.
- Config for disk / max size / allowed types; README documenting the upload seam and the image-processing extension point (intervention/image, pending approval).

Tests (277 total green): valid upload + dimension capture + persistence, event broadcast, disallowed-type and oversize rejection, repository find/list/delete. PHPStan max clean (cms-media added), Pint clean, Rector clean.