### PR TITLE
Phase 4 (1/n): cms-admin — module management admin surface

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -26,6 +26,7 @@ use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use JoelButcher\Socialstream\Filament\SocialstreamPlugin;
+use Liberu\Cms\Admin\Filament\CmsAdminPlugin;
 use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticationPlugin;
 
 class AppPanelProvider extends PanelProvider
@@ -75,6 +76,7 @@ class AppPanelProvider extends PanelProvider
                 Authenticate::class,
             ])
             ->plugins([
+                CmsAdminPlugin::make(),
                 new SocialstreamPlugin,
                 TwoFactorAuthenticationPlugin::make(),
                 FilamentShieldPlugin::make()

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "laravel/reverb": "^1.10",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
+        "liberu-cms/cms-admin": "*",
         "liberu-cms/cms-blocks": "*",
         "liberu-cms/cms-content": "*",
         "liberu-cms/cms-content-types": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c172f1e8c89e88fed28144aeda1506a7",
+    "content-hash": "66c123125ea01d42cca67d127427fc59",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5626,6 +5626,49 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "liberu-cms/cms-admin",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-admin",
+                "reference": "ad64bce5161822251325294166f1be3167451d4e"
+            },
+            "require": {
+                "filament/filament": "^5.0",
+                "illuminate/contracts": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Admin\\AdminServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Admin\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Admin\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Admin module for Liberu CMS: a Filament panel plugin that surfaces the module system and content services to editors and administrators.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
         },
         {
             "name": "liberu-cms/cms-blocks",

--- a/packages/liberu-cms/cms-admin/README.md
+++ b/packages/liberu-cms/cms-admin/README.md
@@ -1,0 +1,40 @@
+# Liberu CMS — Admin
+
+The administrative surface for Liberu CMS. It ships a Filament panel **plugin** that
+exposes the CMS to editors and administrators without putting any feature code in the
+host application.
+
+## What it provides
+
+| Surface | Consumes | Purpose |
+| --- | --- | --- |
+| **Modules** page | `ModuleRegistryInterface`, `ModuleManagerInterface`, `AccessControlInterface` | Review every registered module with its dependency graph and enable/disable optional ones. The manager enforces the safety rules — foundational modules stay on, and a module with enabled dependents cannot be disabled. |
+
+## Permissions
+
+The module declares one permission group via `PermissionRegistrarInterface`:
+
+- `modules.view` — see the Modules page.
+- `modules.manage` — enable or disable a module.
+
+Run `php artisan cms:sync-permissions` (from `cms-users`) to materialise them.
+
+## Wiring it into a panel
+
+The admin surface is opt-in. Register the plugin on any Filament panel:
+
+```php
+use Liberu\Cms\Admin\Filament\CmsAdminPlugin;
+
+$panel->plugins([
+    CmsAdminPlugin::make(),
+]);
+```
+
+Removing that line — or the package — removes the entire admin surface, per the
+removable-module rule.
+
+## Dependencies
+
+Depends only on `cms-contracts` and `cms-core`. It never imports another module,
+so it can be enabled or removed independently of the content modules it administers.

--- a/packages/liberu-cms/cms-admin/composer.json
+++ b/packages/liberu-cms/cms-admin/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "liberu-cms/cms-admin",
+    "description": "Admin module for Liberu CMS: a Filament panel plugin that surfaces the module system and content services to editors and administrators.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "filament/filament": "^5.0",
+        "illuminate/contracts": "^13.0",
+        "illuminate/support": "^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Admin\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Admin\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Admin\\AdminServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-admin/config/admin.php
+++ b/packages/liberu-cms/cms-admin/config/admin.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+     * The Filament navigation group under which every admin surface this module
+     * ships is grouped. Keeping it in config lets a host rebrand the grouping
+     * without touching module code.
+     */
+    'navigation_group' => 'CMS',
+
+    /*
+     * The guard whose permissions gate the admin surfaces. Mirrors cms-users so
+     * authorization resolves against the same backend.
+     */
+    'guard' => 'web',
+];

--- a/packages/liberu-cms/cms-admin/resources/views/filament/pages/module-management.blade.php
+++ b/packages/liberu-cms/cms-admin/resources/views/filament/pages/module-management.blade.php
@@ -1,0 +1,76 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <x-slot name="heading">Installed modules</x-slot>
+
+        <x-slot name="description">
+            Every module registered with the CMS. Enable or disable optional modules; the
+            system keeps dependencies satisfied and never lets a required module be turned off.
+        </x-slot>
+
+        <div class="divide-y divide-gray-100 dark:divide-white/10">
+            @foreach ($this->modules() as $module)
+                <div
+                    wire:key="module-{{ $module->key }}"
+                    class="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                    <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-2">
+                            <span class="text-sm font-semibold text-gray-950 dark:text-white">
+                                {{ $module->name }}
+                            </span>
+
+                            <x-filament::badge color="gray" size="sm">
+                                {{ $module->key }}
+                            </x-filament::badge>
+
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                v{{ $module->version }}
+                            </span>
+                        </div>
+
+                        <div class="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                            @if ($module->enabled)
+                                <x-filament::badge color="success" size="sm">Enabled</x-filament::badge>
+                            @else
+                                <x-filament::badge color="danger" size="sm">Disabled</x-filament::badge>
+                            @endif
+
+                            @if ($module->dependencies !== [])
+                                <span>Requires: {{ implode(', ', $module->dependencies) }}</span>
+                            @endif
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-3">
+                        @if ($module->isToggleable())
+                            @if ($module->enabled)
+                                <x-filament::button
+                                    color="danger"
+                                    size="sm"
+                                    icon="heroicon-o-x-circle"
+                                    wire:click="disable('{{ $module->key }}')"
+                                    wire:confirm="Disable the {{ $module->name }} module?"
+                                >
+                                    Disable
+                                </x-filament::button>
+                            @else
+                                <x-filament::button
+                                    color="success"
+                                    size="sm"
+                                    icon="heroicon-o-check-circle"
+                                    wire:click="enable('{{ $module->key }}')"
+                                >
+                                    Enable
+                                </x-filament::button>
+                            @endif
+                        @else
+                            <span class="text-xs italic text-gray-400 dark:text-gray-500">
+                                {{ $module->lockReason() }}
+                            </span>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </x-filament::section>
+</x-filament-panels::page>

--- a/packages/liberu-cms/cms-admin/src/AdminModule.php
+++ b/packages/liberu-cms/cms-admin/src/AdminModule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Admin;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Admin. Provides the Filament panel surfaces that let administrators operate
+ * the CMS. It consumes only the core module system and the access contracts, so
+ * it can be enabled or removed without dragging any content module along.
+ */
+final class AdminModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'admin';
+    }
+
+    public function name(): string
+    {
+        return 'Admin';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-admin/src/AdminServiceProvider.php
+++ b/packages/liberu-cms/cms-admin/src/AdminServiceProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Admin;
+
+use Liberu\Cms\Contracts\Access\AccessScope;
+use Liberu\Cms\Contracts\Access\PermissionGroup;
+use Liberu\Cms\Contracts\Access\PermissionRegistrarInterface;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+
+final class AdminServiceProvider extends ModuleServiceProvider
+{
+    public function module(): ModuleInterface
+    {
+        return new AdminModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/admin.php', 'cms-admin');
+    }
+
+    protected function bootModule(): void
+    {
+        $this->loadModuleViews(__DIR__.'/../resources/views', 'cms-admin');
+
+        $this->declarePermissions($this->app->make(PermissionRegistrarInterface::class));
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/admin.php' => $this->app->configPath('cms-admin.php'),
+            ], 'cms-admin-config');
+        }
+    }
+
+    private function declarePermissions(PermissionRegistrarInterface $registrar): void
+    {
+        $registrar->register(new PermissionGroup('modules', 'Modules', AccessScope::Module, [
+            'view', 'manage',
+        ]));
+    }
+}

--- a/packages/liberu-cms/cms-admin/src/Filament/CmsAdminPlugin.php
+++ b/packages/liberu-cms/cms-admin/src/Filament/CmsAdminPlugin.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Admin\Filament;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Liberu\Cms\Admin\Filament\Pages\ModuleManagement;
+
+/**
+ * Registers the CMS admin surfaces onto a Filament panel. A host opts in with
+ * `->plugin(CmsAdminPlugin::make())`; removing that one line (or the package)
+ * takes the whole admin surface with it, per the removable-module rule.
+ */
+final class CmsAdminPlugin implements Plugin
+{
+    public static function make(): static
+    {
+        return app(self::class);
+    }
+
+    public function getId(): string
+    {
+        return 'cms-admin';
+    }
+
+    public function register(Panel $panel): void
+    {
+        $panel->pages([
+            ModuleManagement::class,
+        ]);
+    }
+
+    public function boot(Panel $panel): void
+    {
+        //
+    }
+}

--- a/packages/liberu-cms/cms-admin/src/Filament/Pages/ModuleManagement.php
+++ b/packages/liberu-cms/cms-admin/src/Filament/Pages/ModuleManagement.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Admin\Filament\Pages;
+
+use BackedEnum;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Liberu\Cms\Admin\Filament\Support\ModuleView;
+use Liberu\Cms\Contracts\Access\AccessControlInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+use Liberu\Cms\Core\Exceptions\ModuleDependencyException;
+use UnitEnum;
+
+/**
+ * The control room for the module system: lists every registered module with
+ * its dependency graph and lets an administrator enable or disable one, with the
+ * manager enforcing the safety rules (foundational modules stay on; a module
+ * with enabled dependents cannot be turned off).
+ */
+class ModuleManagement extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedPuzzlePiece;
+
+    protected string $view = 'cms-admin::filament.pages.module-management';
+
+    protected static ?string $title = 'Modules';
+
+    protected static ?string $navigationLabel = 'Modules';
+
+    public static function canAccess(): bool
+    {
+        return app(AccessControlInterface::class)->can('modules.view');
+    }
+
+    public static function getNavigationGroup(): string|UnitEnum|null
+    {
+        $group = config('cms-admin.navigation_group', 'CMS');
+
+        return is_string($group) ? $group : 'CMS';
+    }
+
+    /**
+     * The modules to render, in a stable, dependency-first order.
+     *
+     * @return array<int, ModuleView>
+     */
+    public function modules(): array
+    {
+        $registry = app(ModuleRegistryInterface::class);
+        $manager = app(ModuleManagerInterface::class);
+
+        $views = [];
+
+        foreach ($registry->all() as $module) {
+            $key = $module->key();
+
+            $views[] = new ModuleView(
+                key: $key,
+                name: $module->name(),
+                version: $module->version(),
+                enabled: $manager->isEnabled($key),
+                foundational: $module->isFoundational(),
+                dependencies: $module->dependencies(),
+                dependents: $manager->dependentsOf($key),
+            );
+        }
+
+        usort($views, fn (ModuleView $a, ModuleView $b): int => $a->name <=> $b->name);
+
+        return $views;
+    }
+
+    public function enable(string $key): void
+    {
+        $this->authorizeManagement();
+
+        try {
+            app(ModuleManagerInterface::class)->enable($key);
+        } catch (ModuleDependencyException $exception) {
+            $this->failure($exception->getMessage());
+
+            return;
+        }
+
+        Notification::make()
+            ->title("Enabled the \"{$key}\" module.")
+            ->success()
+            ->send();
+    }
+
+    public function disable(string $key): void
+    {
+        $this->authorizeManagement();
+
+        try {
+            app(ModuleManagerInterface::class)->disable($key);
+        } catch (ModuleDependencyException $exception) {
+            $this->failure($exception->getMessage());
+
+            return;
+        }
+
+        Notification::make()
+            ->title("Disabled the \"{$key}\" module.")
+            ->success()
+            ->send();
+    }
+
+    private function authorizeManagement(): void
+    {
+        app(AccessControlInterface::class)->authorize('modules.manage');
+    }
+
+    private function failure(string $message): void
+    {
+        Notification::make()
+            ->title('That change was rejected.')
+            ->body($message)
+            ->danger()
+            ->send();
+    }
+}

--- a/packages/liberu-cms/cms-admin/src/Filament/Support/ModuleView.php
+++ b/packages/liberu-cms/cms-admin/src/Filament/Support/ModuleView.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Admin\Filament\Support;
+
+/**
+ * A read-only projection of a module's state for the admin table. Assembled from
+ * the registry and module manager so the Blade view never touches those services
+ * directly.
+ */
+final readonly class ModuleView
+{
+    /**
+     * @param  array<int, string>  $dependencies  Keys this module requires.
+     * @param  array<int, string>  $dependents  Enabled keys that require this module.
+     */
+    public function __construct(
+        public string $key,
+        public string $name,
+        public string $version,
+        public bool $enabled,
+        public bool $foundational,
+        public array $dependencies,
+        public array $dependents,
+    ) {}
+
+    /**
+     * Whether an administrator may toggle this module. Foundational modules are
+     * permanent, and an enabled module with enabled dependents cannot be
+     * disabled without orphaning them.
+     */
+    public function isToggleable(): bool
+    {
+        if ($this->foundational) {
+            return false;
+        }
+
+        if ($this->enabled && $this->dependents !== []) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function lockReason(): ?string
+    {
+        if ($this->foundational) {
+            return 'Foundational module — always enabled.';
+        }
+
+        if ($this->enabled && $this->dependents !== []) {
+            return 'Required by: '.implode(', ', $this->dependents);
+        }
+
+        return null;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ includes:
 parameters:
     level: max
     paths:
+        - packages/liberu-cms/cms-admin/src
         - packages/liberu-cms/cms-blocks/src
         - packages/liberu-cms/cms-content/src
         - packages/liberu-cms/cms-content-types/src

--- a/tests/Feature/Cms/AdminModuleTest.php
+++ b/tests/Feature/Cms/AdminModuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Contracts\Access\PermissionRegistrarInterface;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
+
+uses(RefreshDatabase::class);
+
+it('registers the admin module in the registry', function (): void {
+    $registry = app(ModuleRegistryInterface::class);
+
+    expect($registry->has('admin'))->toBeTrue()
+        ->and($registry->get('admin')?->name())->toBe('Admin');
+});
+
+it('enables the admin module by default and lets it be disabled', function (): void {
+    $manager = app(ModuleManagerInterface::class);
+
+    expect($manager->isEnabled('admin'))->toBeTrue();
+
+    $manager->disable('admin');
+
+    expect($manager->isEnabled('admin'))->toBeFalse();
+});
+
+it('declares the modules permission group', function (): void {
+    $permissions = app(PermissionRegistrarInterface::class)->permissions();
+
+    expect($permissions)
+        ->toContain('modules.view')
+        ->toContain('modules.manage');
+});

--- a/tests/Feature/Cms/ModuleManagementPageTest.php
+++ b/tests/Feature/Cms/ModuleManagementPageTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Admin\Filament\Pages\ModuleManagement;
+use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
+use Liberu\Cms\Users\Access\SyncPermissions;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Sign a user into the panel holding the given CMS permissions, wired to a
+ * personal team so both Filament tenancy and Spatie's team-scoped permissions
+ * resolve against the same tenant.
+ *
+ * @param  array<int, string>  $permissions
+ */
+function actingAsModuleAdmin(array $permissions = ['modules.view', 'modules.manage']): User
+{
+    $user = User::factory()->create();
+    $team = $user->createPersonalTeam();
+
+    setPermissionsTeamId($team->id);
+    app(SyncPermissions::class)();
+
+    if ($permissions !== []) {
+        $role = Role::create(['name' => 'cms-admin', 'team_id' => $team->id, 'guard_name' => 'web']);
+        $role->givePermissionTo($permissions);
+        $user->syncRoles([$role]);
+    }
+
+    test()->actingAs($user);
+    setPermissionsTeamId($team->id);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant($team);
+
+    return $user;
+}
+
+it('grants access to a user holding modules.view', function (): void {
+    actingAsModuleAdmin(['modules.view']);
+
+    expect(ModuleManagement::canAccess())->toBeTrue();
+});
+
+it('denies access to a user without the modules permission', function (): void {
+    actingAsModuleAdmin([]);
+
+    expect(ModuleManagement::canAccess())->toBeFalse();
+});
+
+it('renders the page listing the registered modules', function (): void {
+    actingAsModuleAdmin();
+
+    Livewire::test(ModuleManagement::class)
+        ->assertSuccessful()
+        ->assertSee('Admin')
+        ->assertSee('Pages');
+});
+
+it('enables a disabled module', function (): void {
+    actingAsModuleAdmin();
+    app(ModuleManagerInterface::class)->disable('hello');
+
+    Livewire::test(ModuleManagement::class)
+        ->call('enable', 'hello');
+
+    expect(app(ModuleManagerInterface::class)->isEnabled('hello'))->toBeTrue();
+});
+
+it('disables an enabled module', function (): void {
+    actingAsModuleAdmin();
+
+    Livewire::test(ModuleManagement::class)
+        ->call('disable', 'hello');
+
+    expect(app(ModuleManagerInterface::class)->isEnabled('hello'))->toBeFalse();
+});
+
+it('forbids managing modules without the modules.manage permission', function (): void {
+    actingAsModuleAdmin(['modules.view']);
+
+    Livewire::test(ModuleManagement::class)
+        ->call('disable', 'hello')
+        ->assertForbidden();
+
+    expect(app(ModuleManagerInterface::class)->isEnabled('hello'))->toBeTrue();
+});
+
+it('refuses to disable a module other enabled modules depend on', function (): void {
+    actingAsModuleAdmin();
+
+    // Pages depends on Media, so Media cannot be disabled while Pages is enabled.
+    Livewire::test(ModuleManagement::class)
+        ->call('disable', 'media');
+
+    expect(app(ModuleManagerInterface::class)->isEnabled('media'))->toBeTrue();
+});


### PR DESCRIPTION
Introduce the Admin module: a Filament panel plugin that surfaces the CMS to administrators without putting feature code in the host app.

This first increment ships the Modules page, a control room over the module system that consumes only cms-core and the access contracts:

- CmsAdminPlugin registers the surface onto a panel; a host opts in with ->plugin(CmsAdminPlugin::make()), and removing that line (or the package) removes the whole admin surface — per the removable-module rule.
- ModuleManagement lists every registered module with its dependency graph and enables/disables optional ones. The manager enforces the safety rules: foundational modules stay on, and a module with enabled dependents cannot be disabled. Rejections surface as notifications, not exceptions.
- Declares the modules.view / modules.manage permission group via the access contract; the page and its actions authorize against them.

Wiring: register liberu-cms/cms-admin and add the plugin to AppPanelProvider; add the package to the PHPStan (max) paths.

Tests: 10 new (module registration + permission group; page access gating, listing, enable/disable, manage authorization, and dependency-safe disable). Full CMS + Filament suites green; PHPStan max clean.