### PR TITLE
Feature/cms api delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,3 +435,17 @@ $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 | decoration-slice | box-decoration-slice |
 | decoration-clone | box-decoration-clone |
 </laravel-boost-guidelines>
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues via the `gh` CLI (`origin` = `ducz07/cms-laravel`, `upstream` = `liberu-cms/cms-laravel`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-role vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context: root `CONTEXT-MAP.md` pointing to a per-package `CONTEXT.md` under `packages/liberu-cms/cms-*`. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,12 @@
+# Context Map
+
+The CMS is a multi-context system; each context is a Composer package under `packages/liberu-cms/cms-*`. This map lists the contexts that have a documented glossary. Contexts gain a `CONTEXT.md` lazily, as their language is resolved during design — absence here means "not yet documented," not "no such context."
+
+## Contexts
+
+- [CMS API](./packages/liberu-cms/cms-api/CONTEXT.md) — headless HTTP delivery layer serving published content to decoupled frontends
+
+## Relationships
+
+- **CMS API → content modules** (cms-pages, cms-posts, cms-menus, cms-content-types): each content module registers its API endpoints and Eloquent Resources into the Delivery API via `ApiResourceRegistryInterface`; the API package never imports a module.
+- **CMS API → host tenancy**: the API resolves the tenant from the Delivery token into a request tenant context that the host's `TenantModelResolverInterface` implementation reads. See `docs/adr/0001-delivery-api-auth-and-tenancy.md`.

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -2,14 +2,20 @@
 
 namespace App\Models;
 
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
+use Laravel\Sanctum\Contracts\HasApiTokens as HasApiTokensContract;
+use Laravel\Sanctum\HasApiTokens;
 
-class Team extends Model
+class Team extends Model implements AuthenticatableContract, HasApiTokensContract
 {
+    use Authenticatable;
+    use HasApiTokens;
     use HasFactory;
 
     #[\Override]

--- a/app/Support/FilamentTenantResolver.php
+++ b/app/Support/FilamentTenantResolver.php
@@ -7,12 +7,17 @@ namespace App\Support;
 use App\Models\Team;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
 use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
 
 /**
  * Host binding for the CMS tenancy contract: the tenant is a Team, active only
  * when multi-tenancy (Spatie teams) is enabled. Lets CMS module models scope to
  * the current team without importing this class.
+ *
+ * The current tenant is resolved from the Delivery API's request tenant context
+ * first (set from the API token's Team), falling back to the Filament panel's
+ * tenant — so the panel and the API share one source of truth.
  */
 final class FilamentTenantResolver implements TenantModelResolverInterface
 {
@@ -23,6 +28,12 @@ final class FilamentTenantResolver implements TenantModelResolverInterface
 
     public function currentTenantId(): int|string|null
     {
+        $apiTenant = app(TenantContextInterface::class)->tenantId();
+
+        if ($apiTenant !== null) {
+            return $apiTenant;
+        }
+
         $tenant = Filament::getTenant();
 
         return $tenant instanceof Model ? $tenant->getKey() : null;

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "liberu-cms/cms-admin": "*",
+        "liberu-cms/cms-api": "*",
         "liberu-cms/cms-blocks": "*",
         "liberu-cms/cms-content": "*",
         "liberu-cms/cms-content-types": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66c123125ea01d42cca67d127427fc59",
+    "content-hash": "c2bcad798e323e1a7b604fac8b919abc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5665,6 +5665,53 @@
                 "MIT"
             ],
             "description": "Admin module for Liberu CMS: a Filament panel plugin that surfaces the module system and content services to editors and administrators.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-api",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-api",
+                "reference": "e612dfbe6030deb8fd36e7eab5a563c5666c0140"
+            },
+            "require": {
+                "illuminate/console": "^13.0",
+                "illuminate/contracts": "^13.0",
+                "illuminate/database": "^13.0",
+                "illuminate/http": "^13.0",
+                "illuminate/routing": "^13.0",
+                "illuminate/support": "^13.0",
+                "laravel/sanctum": "^4.0",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Api\\CmsApiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Api\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Api\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Delivery API for Liberu CMS: a versioned, read-only, Sanctum-authenticated JSON API that serves published content to decoupled frontends.",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/docs/adr/0001-delivery-api-auth-and-tenancy.md
+++ b/docs/adr/0001-delivery-api-auth-and-tenancy.md
@@ -1,0 +1,13 @@
+# Headless delivery API authenticates with Team-owned tokens and resolves tenancy from the token
+
+The Phase 5 read-only delivery API (`cms-api`) authenticates with Sanctum tokens whose **tokenable is the `Team`** (the tenant), so a presented token both authenticates the request and identifies which tenant's published content to serve. Because the existing `TenantModelResolverInterface` only knew the Filament panel's tenant (`Filament::getTenant()`), an `cms-api` middleware sets a request-scoped **tenant context** and the host resolver now reads "API-set tenant first, else Filament tenant" — so the panel and the API share one source of truth and the existing tenancy global scope filters API queries unchanged.
+
+## Considered Options
+
+- **User-owned tokens (reuse `User` `HasApiTokens`)** — rejected: a user can belong to multiple teams, so the token can't unambiguously name a tenant, and a delivery token models an application, not a person.
+- **Explicit `team_id` filtering in every API query** — rejected: it enforces tenancy in two different places (panel global scope + API manual filter), which drifts and risks a cross-tenant leak.
+
+## Consequences
+
+- The `Team` model gains `HasApiTokens`, and the host `FilamentTenantResolver` (plus a small tenant-context holder) is modified — both host-side, which is where tenancy is legitimately bound.
+- Because the authenticated principal is a `Team`, the per-user `AccessControl` gate does not apply to the API; this is acceptable for v1, which serves only **published** content.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,48 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **multi-context** repo: a modular CMS whose contexts live as separate Composer packages under `packages/liberu-cms/cms-*` (e.g. `cms-core`, `cms-pages`, `cms-posts`, `cms-media`, `cms-widgets`, `cms-admin`), each with its own `src/`.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root — it points at one `CONTEXT.md` per context (per package). Read each one relevant to the topic.
+- Per-package **`CONTEXT.md`** under `packages/liberu-cms/<package>/` for the context you're working in.
+- **`docs/adr/`** at the repo root for system-wide decisions, plus `packages/liberu-cms/<package>/docs/adr/` for context-scoped decisions that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Multi-context layout (this repo):
+
+```
+/
+├── CONTEXT-MAP.md                       ← points at each package's CONTEXT.md
+├── docs/adr/                            ← system-wide decisions
+└── packages/liberu-cms/
+    ├── cms-core/
+    │   ├── CONTEXT.md
+    │   ├── docs/adr/                    ← context-specific decisions
+    │   └── src/
+    ├── cms-pages/
+    │   ├── CONTEXT.md
+    │   ├── docs/adr/
+    │   └── src/
+    └── cms-posts/
+        ├── CONTEXT.md
+        ├── docs/adr/
+        └── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in the relevant `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone. This repo has two remotes: `origin` (`ducz07/cms-laravel`, your fork) and `upstream` (`liberu-cms/cms-laravel`). `gh` defaults to `origin`; pass `--repo liberu-cms/cms-laravel` when you need the upstream tracker.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/specs/phase-5-cms-api-delivery.md
+++ b/docs/specs/phase-5-cms-api-delivery.md
@@ -1,0 +1,120 @@
+---
+title: "Phase 5 · Increment 1 — cms-api (read-only headless Delivery API)"
+triage: ready-for-agent
+status: spec
+---
+
+# Phase 5 · Increment 1 — `cms-api` read-only Delivery API
+
+> Publish target: GitHub issue on `ducz07/cms-laravel` with label `ready-for-agent` once `gh` is available. Captured here in the interim.
+
+## Problem Statement
+
+The CMS today can only surface its content through the Filament admin panel and the server-rendered web templates. A team that wants to build a decoupled frontend — a separate SPA, a mobile app, a static-site generator, another service — has no supported way to read published content out of the system. The project's founding rule is "API-first; runs headless," but there is no HTTP API to deliver content to an external consumer, and no way for such a consumer to authenticate or to be scoped to a single tenant's content.
+
+## Solution
+
+Introduce a **Delivery API**: a versioned (`/api/v1`), read-only JSON HTTP surface that serves *published* content — Pages, Posts (with taxonomy), Menus, and Content-Entries — to decoupled frontends. A consumer authenticates with a **Delivery token** (a Sanctum token owned by a Team); presenting the token both authenticates the request and identifies which tenant's content to serve. Content is returned as sanitized HTML, paginated, and scoped to the token's tenant and to the `Published` workflow state.
+
+The API is delivered as a new infrastructure package, `cms-api`, that owns versioning, authentication, the tenant context, rate limiting, and error handling. Each content module registers its own endpoints and Eloquent Resources into the API through a registry contract, so the API package never imports a content module — the same shape as the Phase 4 `AdminResourceRegistry`.
+
+See `docs/adr/0001-delivery-api-auth-and-tenancy.md` for the auth/tenancy decision, and `packages/liberu-cms/cms-api/CONTEXT.md` for the glossary.
+
+## User Stories
+
+1. As a frontend developer, I want to fetch a list of published Pages as JSON, so that I can render them in a decoupled frontend.
+2. As a frontend developer, I want to fetch a single published Page by its slug, so that I can build slug-based routes in my app.
+3. As a frontend developer, I want to fetch a paginated list of published Posts newest-first, so that I can render a blog index without loading everything at once.
+4. As a frontend developer, I want to fetch a single published Post by its slug, so that I can render an article page.
+5. As a frontend developer, I want to filter Posts by category slug, so that I can render a category archive.
+6. As a frontend developer, I want to filter Posts by tag slug, so that I can render a tag archive.
+7. As a frontend developer, I want each Post/Page to include its featured media URL and alt text, so that I can render images without a second request.
+8. As a frontend developer, I want a Post to include its categories and tags inline, so that I can render taxonomy links without extra requests.
+9. As a frontend developer, I want to fetch a Menu by its location, so that I can render site navigation.
+10. As a frontend developer, I want the Menu response to include its ordered item tree (labels, URLs, nesting), so that I can render multi-level navigation.
+11. As a frontend developer, I want to fetch published Content-Entries of a given type, so that I can render custom content that the CMS defines dynamically.
+12. As a frontend developer, I want to fetch a single Content-Entry by slug, so that I can render a custom content detail page.
+13. As a frontend developer, I want a Content-Entry to expose its typed fields as structured JSON, so that I can consume custom schemas without knowing them at build time.
+14. As a frontend developer, I want `content` returned as sanitized HTML, so that I can inject it into the DOM without introducing an XSS vulnerability.
+15. As a frontend developer, I want consistent pagination metadata on every collection, so that I can build "next page" controls generically.
+16. As a frontend developer, I want to control page size with a `per_page` parameter up to a capped maximum, so that I can tune payload size without being able to abuse the API.
+17. As an API consumer, I want to authenticate with a bearer token, so that I can access the tenant's content programmatically.
+18. As an API consumer, I want an unauthenticated request to be rejected with `401`, so that access is gated.
+19. As an API consumer, I want requests scoped automatically to my tenant, so that I only ever see my own Team's content.
+20. As an API consumer, I want a request for another tenant's resource (or an unpublished/non-existent one) to return `404`, so that resource existence across tenants is not leaked.
+21. As an API consumer, I want draft/review/archived content to be invisible, so that only published content is ever delivered.
+22. As an API consumer, I want to be rate-limited per token with a `429` and `Retry-After`, so that I understand and can back off from limits.
+23. As a platform operator, I want to mint a Delivery token for a specific Team from the command line, so that I can onboard a consumer without building UI first.
+24. As a platform operator, I want to revoke a Delivery token, so that I can cut off a compromised or retired consumer.
+25. As a platform operator, I want the API to work when only some content modules are installed, so that a headless deployment can ship a subset of modules.
+26. As a platform operator, I want a README describing routes, auth, and response shapes, so that I can hand consumers a reference without a formal spec yet.
+27. As a security reviewer, I want tenant isolation enforced by the same mechanism the admin panel uses, so that there is one source of truth and no second place for a leak to hide.
+28. As a maintainer, I want each content module to own its own API Resource, so that changing a model's wire shape is a local change in that module.
+29. As a maintainer, I want the API package to depend only on contracts, so that it never imports a content module and the golden rules hold.
+30. As a frontend developer, I want CORS enabled for the API paths, so that a browser app on another origin can call it.
+
+## Implementation Decisions
+
+### Packages
+
+- **New package `cms-api`** (`Liberu\Cms\Api`, path repository, same layout as siblings). Owns: the `/api/v1` route group, the Sanctum auth middleware, the tenant-context mechanism, per-token rate limiting, JSON error handling, CORS enablement for API paths, and the `cms-api:issue-token` command. Depends only on `cms-contracts` and `cms-core`.
+- **Modified content modules** (`cms-pages`, `cms-posts`, `cms-menus`, `cms-content-types`): each registers its API controller + Eloquent Resource into the registry during `registerModule()`, guarded by `app()->bound(ApiResourceRegistryInterface::class)` (headless-safe), exactly as they register Filament resources today.
+- **Modified `cms-media` usage**: no standalone endpoint; a featured-media representation (URL + alt) is embedded in Page/Post Resources via the existing media contract.
+- **Host changes** (permitted — tenancy is bound in the host): add `HasApiTokens` to the `Team` model; make the host `TenantModelResolverInterface` implementation read the API-set tenant context first, falling back to `Filament::getTenant()`.
+
+### Contracts / interfaces
+
+- **New `ApiResourceRegistryInterface`** in `cms-contracts`, mirroring `AdminResourceRegistryInterface`: a module announces the API endpoint(s) it owns, tagged by module key; `cms-api` reads the catalogue to build routes. Shape follows the admin registry (register + list, grouped by module key).
+- **Tenant context**: a request-scoped holder (bound in `cms-api`) that names the current tenant during an API request. The API auth middleware sets it from the authenticated Team. The host tenancy resolver reads it before Filament. This keeps the existing tenancy global scope working unchanged for API queries.
+- **Reuse existing repository contracts** for all reads: `PageRepositoryInterface` (`findBySlug`, `published`, `roots`), `PostRepositoryInterface` (`findBySlug`, `published`, `byCategory`, `byTag`), `ContentEntryRepositoryInterface` (`findBySlug`, `ofType`, `published`), `MenuRepositoryInterface` (`forLocation`). No new query logic; single-item lookups apply a published check at the controller/Resource boundary where `findBySlug` currently ignores status.
+
+### Auth & tenancy (see ADR-0001)
+
+- Sanctum tokens whose **tokenable is `Team`**. `auth:sanctum` returns the Team; the Team *is* the tenant.
+- The Delivery token carries a read ability/scope; v1 only reads, so a single read ability suffices.
+- Cross-tenant / unpublished / missing resources are indistinguishable from the consumer's side — all `404` — so existence is not leaked across tenants.
+
+### API contract
+
+- **Versioning**: URI path `/api/v1`.
+- **Routes** (indicative, not binding on exact strings): collection + single per resource; Posts collection accepts `category` / `tag` / `per_page`; Menus fetched by location.
+- **Serialization**: one Eloquent API Resource per exposed model, owned by its module. Internal columns (`team_id`, workflow internals, timestamps not needed by consumers) are omitted.
+- **`content` field**: returned as HTML sanitized through the existing `Liberu\Cms\Content\Support\HtmlSanitizer`; `excerpt` as plain text.
+- **Pagination**: page-based, standard `JsonResource` `data`/`meta`/`links`; `per_page` honored up to a hard cap from config.
+- **Rate limiting**: per-token throttle on the `/api/v1` group, default from `config('cms-api.rate_limit')`, `429` + `Retry-After`; per-IP fallback for unauthenticated paths.
+- **Errors**: Laravel default JSON exception rendering — `401` (missing/invalid token), `404` (unknown slug / unpublished / cross-tenant), `429` (throttle).
+- **CORS**: enabled for `api/v1/*`.
+
+### Operations
+
+- **`cms-api:issue-token {team}`** artisan command mints a Delivery token for a Team and prints it once. Revocation via Sanctum's token deletion (documented in the README). Admin UI for token management is out of scope.
+
+### Registration/ordering
+
+- `cms-api` binds `ApiResourceRegistryInterface` in its `register()`; it must register before the content modules so their `app()->bound(...)` guard passes — the same ordering constraint proved by `cms-admin`. `cms-api` reads the populated registry and defines routes in `boot()` (after all providers have registered), carrying over the Phase 4 provider-timing lesson.
+
+## Testing Decisions
+
+- **What a good test is here**: asserts *external behavior* of the Delivery API — the HTTP contract — not internal wiring. It issues a real Delivery token, calls a real `/api/v1` route, and asserts status code and JSON shape/visibility. It does not assert controller internals, registry internals, or query builder calls.
+- **Single, highest seam**: Pest **feature tests** hitting `/api/v1/*` end to end (route → auth + tenant-context middleware → controller → repository → Resource → JSON).
+- **Modules tested**: `cms-api` (auth, tenant context, versioning, rate limiting, error shapes) and each content endpoint (Pages, Posts + taxonomy, Menus, Content-Entries) via feature tests. Host `Team` token issuance covered through the `cms-api:issue-token` command + an authenticated request.
+- **Coverage to include**: published content is returned; draft/review/archived is invisible (`404`/absent); unauthenticated request is `401`; cross-tenant resource is `404` (isolation); `content` is returned sanitized (XSS payload stripped through the endpoint, mirroring `PageContentSanitizationTest`); pagination metadata present and `per_page` capped; taxonomy filters return the right subset; rate limit returns `429`.
+- **Prior art**: existing module resource tests that register the tenancy global scope + creation observer in `beforeEach`; `TenantIsolationTest`; `PageContentSanitizationTest` (payload stripped through the public controller) as the model for the API sanitization test; model factories with existing states (e.g. Page factory `home()` / published states).
+
+## Out of Scope
+
+- Write/CRUD operations (create/update/delete) — a later Phase-5 increment.
+- Free-text **Search** — its own Phase-5 increment; the taxonomy filter here is not search.
+- **SEO** (sitemaps, structured data), **Forms**, **Notifications** — later Phase-5 increments.
+- Preview/draft access via token scope — future; v1 serves only published content.
+- Standalone browsable Media endpoint — media is embedded only.
+- Generated **OpenAPI** spec and an admin **token-management UI** — deferred follow-ups (README ships in v1).
+- Generic query grammar: `?include`, `?fields`, arbitrary `?filter`, sorting, GraphQL — deliberately excluded.
+- ContentType definitions as an endpoint (schemas are global/shared); only Content-*Entries* are delivered.
+
+## Further Notes
+
+- **Tracer bullet**: build **Pages first**. It exercises the entire stack once — the registry contract, the `/api/v1` route group, Sanctum Team-token auth, the tenant context + resolver change, the Eloquent Resource, and HTML sanitization. Once Pages is green end to end, Posts (+taxonomy), Menus, and Content-Entries are the same pattern repeated and can be separate tickets.
+- **Toolchain**: Windows/Herd — run PHP/Composer via PowerShell; `composer` operations need `--ignore-platform-reqs` (see the `windows-herd-toolchain` memory).
+- **Gates** (per existing CI): Pint, PHPStan max (+Larastan), and the full Pest suite must stay green; add `cms-api` to `phpstan.neon`.
+- **Menus caveat**: Menus have no workflow state, so "published" doesn't apply; `forLocation` is the visibility seam, still tenant-scoped.

--- a/packages/liberu-cms/cms-api/CONTEXT.md
+++ b/packages/liberu-cms/cms-api/CONTEXT.md
@@ -1,0 +1,21 @@
+# CMS API
+
+The headless HTTP delivery layer over the CMS content modules: a versioned, Sanctum-authenticated JSON API that serves published content to decoupled frontends. Infrastructure lives here; each content module registers its own resources.
+
+## Language
+
+**Delivery API**:
+The read-only, versioned (`/api/v1`) HTTP surface that serves published content as JSON to external consumers.
+_Avoid_: content API, public API, REST layer
+
+**Delivery token**:
+A Sanctum token whose tokenable is a `Team`, granting a consumer read access to that one tenant's published content. Authenticates and identifies the tenant in a single credential.
+_Avoid_: API key, access token, user token
+
+**Tenant context**:
+The request-scoped holder that names the current tenant during an API request, set from the Delivery token. The tenancy resolver reads it before falling back to the Filament panel's tenant.
+_Avoid_: current team, active tenant, scope
+
+**API resource registry**:
+The contract (`ApiResourceRegistryInterface`) through which a content module contributes its API endpoints and Eloquent Resources to the Delivery API, without the API package importing the module.
+_Avoid_: resource map, route registry

--- a/packages/liberu-cms/cms-api/README.md
+++ b/packages/liberu-cms/cms-api/README.md
@@ -1,0 +1,78 @@
+# CMS API — Delivery API
+
+A versioned (`/api/v1`), read-only, Sanctum-authenticated JSON API that serves
+**published** CMS content to decoupled frontends. This package owns the route
+group, authentication, the request tenant context, per-token rate limiting, and
+CORS. Each content module contributes its own endpoints and Eloquent Resources
+through `ApiResourceRegistryInterface`, so this package never imports a content
+module.
+
+## Authentication
+
+Every request must present a **Delivery token** as a bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+A Delivery token is a Sanctum token whose tokenable is a **Team** — the tenant.
+Presenting it both authenticates the request and scopes every read to that one
+Team's published content. A missing or invalid token returns `401`.
+
+### Issuing a token
+
+```
+php artisan cms-api:issue-token {team} [--name=delivery]
+```
+
+Prints the plaintext token once. Store it immediately; it is not recoverable.
+
+### Revoking a token
+
+Delete the corresponding row from `personal_access_tokens` (e.g. via
+`$team->tokens()->where('id', $id)->delete()`), or delete all of a Team's tokens
+with `$team->tokens()->delete()`.
+
+## Tenancy & visibility
+
+- Reads are scoped to the token's Team automatically — you only ever see your own
+  content.
+- Only **published** content is delivered. Draft / review / archived content, a
+  resource belonging to another tenant, and a non-existent resource are all
+  indistinguishable: each returns `404`, so existence is never leaked across
+  tenants.
+
+## Rate limiting
+
+The `/api/v1` group is throttled per token (default 60 requests/minute, see
+`config('cms-api.rate_limit')`). Exceeding the limit returns `429` with a
+`Retry-After` header.
+
+## Pagination
+
+Collection endpoints return the standard `data` / `meta` / `links` envelope.
+Control the page size with `?per_page=` up to the cap in
+`config('cms-api.pagination.max')` (default 100).
+
+## Routes (v1)
+
+| Method | URI | Description |
+| ------ | --- | ----------- |
+| GET | `/api/v1/pages` | Published pages |
+| GET | `/api/v1/pages/{slug}` | A published page by slug |
+| GET | `/api/v1/posts` | Published posts, newest first (`?category=`, `?tag=`, `?per_page=`) |
+| GET | `/api/v1/posts/{slug}` | A published post by slug (categories, tags, featured media inline) |
+| GET | `/api/v1/menus/{location}` | A menu by location, with its ordered item tree |
+| GET | `/api/v1/content/{type}` | Published entries of a content type |
+| GET | `/api/v1/content/{type}/{slug}` | A published content entry by slug |
+
+Exact routes depend on which content modules are installed; a headless
+deployment can ship a subset of modules and the API exposes only their
+endpoints.
+
+## CORS
+
+The package enables CORS for `api/v1/*` by merging its own `cors` config into the
+host's (the host's own `config/cors.php` values win), so a browser app on another
+origin can call the API. When running with `config:cache`, publish the host CORS
+config so the settings persist.

--- a/packages/liberu-cms/cms-api/composer.json
+++ b/packages/liberu-cms/cms-api/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "liberu-cms/cms-api",
+    "description": "Delivery API for Liberu CMS: a versioned, read-only, Sanctum-authenticated JSON API that serves published content to decoupled frontends.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "illuminate/console": "^13.0",
+        "illuminate/contracts": "^13.0",
+        "illuminate/database": "^13.0",
+        "illuminate/http": "^13.0",
+        "illuminate/routing": "^13.0",
+        "illuminate/support": "^13.0",
+        "laravel/sanctum": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Api\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Api\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Api\\CmsApiServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-api/config/cms-api.php
+++ b/packages/liberu-cms/cms-api/config/cms-api.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Per-token rate limit
+    |--------------------------------------------------------------------------
+    |
+    | Requests per minute allowed on the /api/v1 group, keyed by the token's
+    | Team (or the client IP for anything not yet authenticated). Exceeding it
+    | yields a 429 with a Retry-After header.
+    |
+    */
+
+    'rate_limit' => (int) env('CMS_API_RATE_LIMIT', 60),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination
+    |--------------------------------------------------------------------------
+    |
+    | The default page size and the hard cap a consumer may request via the
+    | `per_page` query parameter.
+    |
+    */
+
+    'pagination' => [
+        'default' => (int) env('CMS_API_PER_PAGE', 15),
+        'max' => (int) env('CMS_API_MAX_PER_PAGE', 100),
+    ],
+
+];

--- a/packages/liberu-cms/cms-api/config/cors.php
+++ b/packages/liberu-cms/cms-api/config/cors.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+|--------------------------------------------------------------------------
+| Delivery API CORS
+|--------------------------------------------------------------------------
+|
+| The Delivery API owns CORS for its own paths so a browser app on another
+| origin can call it. These values are merged into the host's `cors` config
+| (the host's own settings win), enabling CORS on the versioned API group.
+|
+*/
+
+return [
+    'paths' => ['api/v1/*'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => ['*'],
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => false,
+];

--- a/packages/liberu-cms/cms-api/src/ApiResourceRegistry.php
+++ b/packages/liberu-cms/cms-api/src/ApiResourceRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api;
+
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
+
+/**
+ * In-memory catalogue of module-contributed Delivery API endpoints, grouped by
+ * the owning module key. Mirrors AdminResourceRegistry.
+ */
+final class ApiResourceRegistry implements ApiResourceRegistryInterface
+{
+    /**
+     * @var array<string, array<int, ApiEndpoint>>
+     */
+    private array $endpoints = [];
+
+    public function registerEndpoint(string $moduleKey, ApiEndpoint $endpoint): void
+    {
+        $this->endpoints[$moduleKey][] = $endpoint;
+    }
+
+    public function endpoints(): array
+    {
+        return $this->endpoints;
+    }
+}

--- a/packages/liberu-cms/cms-api/src/CmsApiModule.php
+++ b/packages/liberu-cms/cms-api/src/CmsApiModule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * CMS API. Provides the headless Delivery API: the versioned route group,
+ * Sanctum Team-token authentication, the request tenant context, per-token rate
+ * limiting, and CORS. It consumes only contracts and the core module system, so
+ * it can be enabled or removed without dragging any content module along.
+ */
+final class CmsApiModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'api';
+    }
+
+    public function name(): string
+    {
+        return 'CMS API';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-api/src/CmsApiServiceProvider.php
+++ b/packages/liberu-cms/cms-api/src/CmsApiServiceProvider.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+use Laravel\Sanctum\Contracts\HasApiTokens;
+use Laravel\Sanctum\PersonalAccessToken;
+use Liberu\Cms\Api\Console\IssueTokenCommand;
+use Liberu\Cms\Api\Http\Middleware\ForceJsonResponse;
+use Liberu\Cms\Api\Http\Middleware\SetApiTenant;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+
+/**
+ * Owns the Delivery API infrastructure: it binds the endpoint registry before
+ * the content modules register (so their `app()->bound(...)` guard passes), then
+ * in boot() — after every provider has registered — reads the populated registry
+ * and defines the versioned, authenticated, rate-limited route group. This is
+ * the Phase 4 registry + provider-timing pattern applied to the API.
+ */
+final class CmsApiServiceProvider extends ModuleServiceProvider
+{
+    private const string VERSION = 'v1';
+
+    private const string RATE_LIMITER = 'cms-api';
+
+    public function module(): ModuleInterface
+    {
+        return new CmsApiModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/cms-api.php', 'cms-api');
+        $this->mergeModuleConfig(__DIR__.'/../config/cors.php', 'cors');
+
+        $this->app->singleton(ApiResourceRegistryInterface::class, ApiResourceRegistry::class);
+    }
+
+    protected function bootModule(): void
+    {
+        $this->configureRateLimiting();
+        $this->registerRoutes();
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([IssueTokenCommand::class]);
+
+            $this->publishes([
+                __DIR__.'/../config/cms-api.php' => $this->app->configPath('cms-api.php'),
+            ], 'cms-api-config');
+        }
+    }
+
+    private function configureRateLimiting(): void
+    {
+        RateLimiter::for(self::RATE_LIMITER, function (Request $request): Limit {
+            $configured = config('cms-api.rate_limit', 60);
+            $perMinute = is_numeric($configured) ? (int) $configured : 60;
+
+            return Limit::perMinute($perMinute)->by(self::RATE_LIMITER.':'.$this->throttleKey($request));
+        });
+    }
+
+    /**
+     * Throttle per Delivery token when authenticated, else per client IP.
+     */
+    private function throttleKey(Request $request): string
+    {
+        $principal = $request->user();
+
+        if ($principal instanceof HasApiTokens) {
+            $token = $principal->currentAccessToken();
+
+            if ($token instanceof PersonalAccessToken) {
+                $id = $token->getKey();
+
+                return 'token:'.(is_int($id) || is_string($id) ? (string) $id : '');
+            }
+        }
+
+        return 'ip:'.($request->ip() ?? 'unknown');
+    }
+
+    private function registerRoutes(): void
+    {
+        $endpoints = $this->app->make(ApiResourceRegistryInterface::class)->endpoints();
+
+        if ($endpoints === []) {
+            return;
+        }
+
+        Route::prefix('api/'.self::VERSION)
+            ->middleware([
+                ForceJsonResponse::class,
+                'auth:sanctum',
+                SetApiTenant::class,
+                'throttle:'.self::RATE_LIMITER,
+                SubstituteBindings::class,
+            ])
+            ->group(function () use ($endpoints): void {
+                foreach ($endpoints as $group) {
+                    foreach ($group as $endpoint) {
+                        Route::match([$endpoint->method], $endpoint->uri, [$endpoint->controller, $endpoint->action])
+                            ->name('cms-api.'.$endpoint->name);
+                    }
+                }
+            });
+    }
+}

--- a/packages/liberu-cms/cms-api/src/Console/IssueTokenCommand.php
+++ b/packages/liberu-cms/cms-api/src/Console/IssueTokenCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Sanctum\Contracts\HasApiTokens;
+use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
+
+/**
+ * Mints a Delivery token for a Team and prints it once. Onboards an API consumer
+ * from the command line before any token-management UI exists. Revoke a token by
+ * deleting the corresponding personal access token row (see the README).
+ */
+final class IssueTokenCommand extends Command
+{
+    protected $signature = 'cms-api:issue-token {team : The Team (tenant) id to issue a Delivery token for}
+        {--name=delivery : A human-readable label for the token}';
+
+    protected $description = 'Issue a read-only Delivery API token for a Team.';
+
+    public function handle(TenantModelResolverInterface $resolver): int
+    {
+        $model = $resolver->tenantModel();
+
+        if ($model === null) {
+            $this->error('Multi-tenancy is disabled; there is no Team model to issue a Delivery token for.');
+
+            return self::FAILURE;
+        }
+
+        $teamId = $this->argument('team');
+        $team = $model::query()->find($teamId);
+
+        if (! $team instanceof HasApiTokens) {
+            $this->error(sprintf('No Team found with id [%s].', is_scalar($teamId) ? (string) $teamId : ''));
+
+            return self::FAILURE;
+        }
+
+        $token = $team->createToken((string) $this->option('name'), ['content:read']);
+
+        $this->info('Delivery token issued. Store it now — it will not be shown again:');
+        $this->line($token->plainTextToken);
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/liberu-cms/cms-api/src/Http/Middleware/ForceJsonResponse.php
+++ b/packages/liberu-cms/cms-api/src/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Forces every Delivery API request to be treated as a JSON request, so
+ * authentication and validation failures are rendered as JSON status responses
+ * (e.g. a clean 401) rather than redirected to a web login route. The API has no
+ * HTML surface, so this holds for browser `fetch` calls that omit an Accept
+ * header just as it does for explicit JSON clients.
+ */
+final class ForceJsonResponse
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}

--- a/packages/liberu-cms/cms-api/src/Http/Middleware/SetApiTenant.php
+++ b/packages/liberu-cms/cms-api/src/Http/Middleware/SetApiTenant.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Api\Http\Middleware;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Sets the request tenant context from the authenticated principal. Because the
+ * Delivery token's tokenable is a Team, `auth:sanctum` has already resolved the
+ * Team onto the request; naming it in the tenant context makes the tenancy
+ * resolver — and therefore the tenant global scope — filter every query in this
+ * request to that one tenant.
+ */
+final readonly class SetApiTenant
+{
+    public function __construct(private TenantContextInterface $context) {}
+
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $team = $request->user();
+
+        if ($team instanceof Model) {
+            $key = $team->getKey();
+            $this->context->setTenantId(is_int($key) || is_string($key) ? $key : null);
+        }
+
+        return $next($request);
+    }
+}

--- a/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
+++ b/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
@@ -7,12 +7,15 @@ namespace Liberu\Cms\ContentTypes;
 use Liberu\Cms\ContentTypes\Contracts\ContentEntryRepositoryInterface;
 use Liberu\Cms\ContentTypes\Filament\ContentEntryResource;
 use Liberu\Cms\ContentTypes\Filament\ContentTypeResource;
+use Liberu\Cms\ContentTypes\Http\Controllers\ContentEntryApiController;
 use Liberu\Cms\ContentTypes\Models\ContentEntry;
 use Liberu\Cms\ContentTypes\Repositories\ContentEntryRepository;
 use Liberu\Cms\ContentTypes\Schema\SchemaValidator;
 use Liberu\Cms\Contracts\Admin\AdminDashboardRegistryInterface;
 use Liberu\Cms\Contracts\Admin\AdminResourceRegistryInterface;
 use Liberu\Cms\Contracts\Admin\DashboardStat;
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 
@@ -32,6 +35,12 @@ final class ContentTypesServiceProvider extends ModuleServiceProvider
             $registry = $this->app->make(AdminResourceRegistryInterface::class);
             $registry->registerResource('content-types', ContentTypeResource::class);
             $registry->registerResource('content-types', ContentEntryResource::class);
+        }
+
+        if ($this->app->bound(ApiResourceRegistryInterface::class)) {
+            $registry = $this->app->make(ApiResourceRegistryInterface::class);
+            $registry->registerEndpoint('content-types', new ApiEndpoint('content/{type}', ContentEntryApiController::class, 'index', 'content.index'));
+            $registry->registerEndpoint('content-types', new ApiEndpoint('content/{type}/{slug}', ContentEntryApiController::class, 'show', 'content.show'));
         }
     }
 

--- a/packages/liberu-cms/cms-content-types/src/Http/Controllers/ContentEntryApiController.php
+++ b/packages/liberu-cms/cms-content-types/src/Http/Controllers/ContentEntryApiController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Http\Controllers;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Liberu\Cms\ContentTypes\Contracts\ContentEntryRepositoryInterface;
+use Liberu\Cms\ContentTypes\Http\Resources\ContentEntryResource;
+use Liberu\Cms\ContentTypes\Models\ContentEntry;
+use Liberu\Cms\ContentTypes\Models\ContentType;
+use Liberu\Cms\Core\Support\ApiPagination;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Serves published Content-Entries of a given type over the Delivery API. The
+ * repository reads are tenant-scoped; the published check is applied at this
+ * boundary because `ofType`/`findBySlug` ignore workflow state.
+ */
+final readonly class ContentEntryApiController
+{
+    public function __construct(private ContentEntryRepositoryInterface $entries) {}
+
+    public function index(string $type): AnonymousResourceCollection
+    {
+        $entries = array_values(array_filter(
+            $this->entries->ofType($type),
+            static fn (ContentEntry $entry): bool => $entry->isLive(),
+        ));
+
+        return ContentEntryResource::collection(ApiPagination::fromArray($entries));
+    }
+
+    public function show(string $type, string $slug): ContentEntryResource
+    {
+        $entry = $this->entries->findBySlug($slug);
+
+        if (! $entry instanceof ContentEntry || ! $entry->isLive() || $this->typeKey($entry) !== $type) {
+            throw new NotFoundHttpException;
+        }
+
+        return new ContentEntryResource($entry);
+    }
+
+    private function typeKey(ContentEntry $entry): ?string
+    {
+        $type = $entry->type;
+
+        return $type instanceof ContentType ? $type->key : null;
+    }
+}

--- a/packages/liberu-cms/cms-content-types/src/Http/Resources/ContentEntryResource.php
+++ b/packages/liberu-cms/cms-content-types/src/Http/Resources/ContentEntryResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\Cms\ContentTypes\Models\ContentEntry;
+use Liberu\Cms\ContentTypes\Models\ContentType;
+
+/**
+ * The Delivery API wire shape for a Content-Entry: its type key, title, slug,
+ * and its typed fields as structured JSON, so a consumer can render custom
+ * schemas it does not know at build time.
+ *
+ * @mixin ContentEntry
+ */
+final class ContentEntryResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $type = $this->type;
+
+        return [
+            'id' => $this->id,
+            'type' => $type instanceof ContentType ? $type->key : null,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'fields' => $this->data ?? [],
+            'published_at' => $this->publishedAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-contracts/src/Api/ApiEndpoint.php
+++ b/packages/liberu-cms/cms-contracts/src/Api/ApiEndpoint.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Api;
+
+/**
+ * A single Delivery API endpoint a content module contributes to the API.
+ *
+ * The module names the URI (relative to the version prefix), the controller
+ * class and method that serve it, and a route-name suffix. The API package
+ * reads these descriptors to define the versioned route group, so it never
+ * imports the module's controller by name.
+ */
+final class ApiEndpoint
+{
+    /**
+     * @param  string  $uri  Path relative to the version prefix, e.g. "pages" or "pages/{slug}".
+     * @param  class-string  $controller  The controller class serving the endpoint.
+     * @param  string  $action  The controller method to invoke.
+     * @param  string  $name  Route-name suffix, e.g. "pages.index".
+     * @param  string  $method  The HTTP verb.
+     */
+    public function __construct(
+        public string $uri,
+        public string $controller,
+        public string $action,
+        public string $name,
+        public string $method = 'GET',
+    ) {}
+}

--- a/packages/liberu-cms/cms-contracts/src/Api/ApiResourceRegistryInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Api/ApiResourceRegistryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Api;
+
+/**
+ * The catalogue of Delivery API endpoints modules contribute to the API.
+ *
+ * A module announces the endpoint(s) it owns during the register phase, tagged
+ * with its module key. The API module reads the catalogue in boot() to define
+ * the versioned route group — so the API surface tracks the installed modules
+ * without the API module ever importing one. Mirrors AdminResourceRegistry.
+ */
+interface ApiResourceRegistryInterface
+{
+    /**
+     * Announce a Delivery API endpoint owned by a module.
+     *
+     * @param  string  $moduleKey  The owning module's key, e.g. "pages".
+     */
+    public function registerEndpoint(string $moduleKey, ApiEndpoint $endpoint): void;
+
+    /**
+     * Every registered endpoint, grouped by the owning module key.
+     *
+     * @return array<string, array<int, ApiEndpoint>>
+     */
+    public function endpoints(): array;
+}

--- a/packages/liberu-cms/cms-contracts/src/Tenancy/TenantContextInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Tenancy/TenantContextInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Tenancy;
+
+/**
+ * The request-scoped holder that names the current tenant during a Delivery API
+ * request. The API auth middleware sets it from the authenticated Team; the host
+ * tenancy resolver reads it before falling back to the Filament panel's tenant,
+ * so the panel and the API share one source of truth for tenancy.
+ */
+interface TenantContextInterface
+{
+    /**
+     * The current tenant's key, or null when none is set for this request.
+     */
+    public function tenantId(): int|string|null;
+
+    public function setTenantId(int|string|null $tenantId): void;
+}

--- a/packages/liberu-cms/cms-core/src/CmsCoreServiceProvider.php
+++ b/packages/liberu-cms/cms-core/src/CmsCoreServiceProvider.php
@@ -11,6 +11,7 @@ use Liberu\Cms\Contracts\Events\EventBusInterface;
 use Liberu\Cms\Contracts\Module\ModuleManagerInterface;
 use Liberu\Cms\Contracts\Module\ModuleRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleStateRepositoryInterface;
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
 use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
 use Liberu\Cms\Core\Console\MakeModuleCommand;
 use Liberu\Cms\Core\Events\EventBus;
@@ -18,6 +19,7 @@ use Liberu\Cms\Core\Module\DatabaseModuleStateRepository;
 use Liberu\Cms\Core\Module\ModuleManager;
 use Liberu\Cms\Core\Module\ModuleRegistry;
 use Liberu\Cms\Core\Tenant\NullTenantResolver;
+use Liberu\Cms\Core\Tenant\RequestTenantContext;
 
 /**
  * The CMS kernel provider.
@@ -52,6 +54,8 @@ final class CmsCoreServiceProvider extends ServiceProvider
         $this->app->singleton(EventBusInterface::class, fn (): EventBus => new EventBus($this->app));
 
         $this->app->bindIf(TenantModelResolverInterface::class, NullTenantResolver::class);
+
+        $this->app->singleton(TenantContextInterface::class, RequestTenantContext::class);
     }
 
     /**

--- a/packages/liberu-cms/cms-core/src/Http/Concerns/EmbedsFeaturedMedia.php
+++ b/packages/liberu-cms/cms-core/src/Http/Concerns/EmbedsFeaturedMedia.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Http\Concerns;
+
+use Liberu\Cms\Contracts\Media\MediaItemInterface;
+
+/**
+ * Shared wire shape for a featured media item embedded in a Delivery API
+ * Resource: a public URL and its alt text, or null when there is no image. Kept
+ * in one place so the media representation cannot drift between the modules that
+ * embed it.
+ */
+trait EmbedsFeaturedMedia
+{
+    /**
+     * @return array{url: string, alt: mixed}|null
+     */
+    protected function featuredMediaPayload(?MediaItemInterface $media): ?array
+    {
+        if ($media === null) {
+            return null;
+        }
+
+        return [
+            'url' => $media->url(),
+            'alt' => $media->metadata()['alt'] ?? null,
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Support/ApiPagination.php
+++ b/packages/liberu-cms/cms-core/src/Support/ApiPagination.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Support;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+/**
+ * Turns a repository's array of live models into a page-based paginator with the
+ * standard `data`/`meta`/`links` shape, honouring the consumer's `per_page` up
+ * to the API's hard cap. Centralised here so every Delivery API collection
+ * endpoint paginates identically without depending on the API package.
+ *
+ * @internal Used by content modules' Delivery API controllers.
+ */
+final class ApiPagination
+{
+    /**
+     * @param  array<int, mixed>  $items
+     * @return LengthAwarePaginator<int, mixed>
+     */
+    public static function fromArray(array $items): LengthAwarePaginator
+    {
+        $defaultRaw = config('cms-api.pagination.default', 15);
+        $maxRaw = config('cms-api.pagination.max', 100);
+
+        $default = is_numeric($defaultRaw) ? (int) $defaultRaw : 15;
+        $max = is_numeric($maxRaw) ? (int) $maxRaw : 100;
+
+        $requested = request()->has('per_page')
+            ? request()->integer('per_page')
+            : $default;
+
+        $perPage = max(1, min($requested, $max));
+
+        $collection = Collection::make($items);
+        $page = LengthAwarePaginator::resolveCurrentPage();
+
+        return new LengthAwarePaginator(
+            $collection->forPage($page, $perPage)->values(),
+            $collection->count(),
+            $perPage,
+            $page,
+            [
+                'path' => LengthAwarePaginator::resolveCurrentPath(),
+                'query' => request()->query(),
+            ],
+        );
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Tenant/HasTenant.php
+++ b/packages/liberu-cms/cms-core/src/Tenant/HasTenant.php
@@ -18,6 +18,11 @@ use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
  */
 trait HasTenant
 {
+    public static function bootHasTenant(): void
+    {
+        static::addGlobalScope(new TenantScope);
+    }
+
     /**
      * @return BelongsTo<Model, $this>
      */

--- a/packages/liberu-cms/cms-core/src/Tenant/RequestTenantContext.php
+++ b/packages/liberu-cms/cms-core/src/Tenant/RequestTenantContext.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Tenant;
+
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
+
+/**
+ * In-memory, request-scoped tenant context. Bound as a singleton so the API
+ * middleware, the tenancy resolver, and the tenant global scope all read the
+ * same value for the lifetime of a request.
+ */
+final class RequestTenantContext implements TenantContextInterface
+{
+    private int|string|null $tenantId = null;
+
+    public function tenantId(): int|string|null
+    {
+        return $this->tenantId;
+    }
+
+    public function setTenantId(int|string|null $tenantId): void
+    {
+        $this->tenantId = $tenantId;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Tenant/TenantScope.php
+++ b/packages/liberu-cms/cms-core/src/Tenant/TenantScope.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Tenant;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
+
+/**
+ * Constrains a tenant-scoped model's queries to the tenant named in the request
+ * tenant context. The context is only set where there is no Filament panel to do
+ * the scoping — the Delivery API sets it from the token's Team — so API reads see
+ * only that tenant's content. Inside the Filament panel the context is empty and
+ * this scope is a no-op, leaving the panel's own tenancy scope as the single
+ * mechanism there; likewise plain web and console reads are untouched.
+ *
+ * @implements Scope<Model>
+ */
+final class TenantScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $tenantId = app(TenantContextInterface::class)->tenantId();
+
+        if ($tenantId === null) {
+            return;
+        }
+
+        $builder->where($model->qualifyColumn('team_id'), $tenantId);
+    }
+}

--- a/packages/liberu-cms/cms-menus/src/Http/Controllers/MenuApiController.php
+++ b/packages/liberu-cms/cms-menus/src/Http/Controllers/MenuApiController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Menus\Http\Controllers;
+
+use Liberu\Cms\Menus\Contracts\MenuRepositoryInterface;
+use Liberu\Cms\Menus\Http\Resources\MenuResource;
+use Liberu\Cms\Menus\Models\Menu;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Serves a Menu by its navigation location over the Delivery API. Menus carry no
+ * workflow state, so `forLocation` — tenant-scoped like every other read — is
+ * the visibility seam.
+ */
+final readonly class MenuApiController
+{
+    public function __construct(private MenuRepositoryInterface $menus) {}
+
+    public function show(string $location): MenuResource
+    {
+        $menu = $this->menus->forLocation($location);
+
+        if (! $menu instanceof Menu) {
+            throw new NotFoundHttpException;
+        }
+
+        return new MenuResource($menu);
+    }
+}

--- a/packages/liberu-cms/cms-menus/src/Http/Resources/MenuResource.php
+++ b/packages/liberu-cms/cms-menus/src/Http/Resources/MenuResource.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Menus\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\Cms\Menus\Models\Menu;
+use Liberu\Cms\Menus\Models\MenuItem;
+
+/**
+ * The Delivery API wire shape for a Menu: its name, location, and the ordered,
+ * nested item tree (labels, URLs, children) so a consumer can render multi-level
+ * navigation directly.
+ *
+ * @mixin Menu
+ */
+final class MenuResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'location' => $this->location,
+            'items' => $this->buildTree($this->items()->get()->all(), null),
+        ];
+    }
+
+    /**
+     * @param  array<int, MenuItem>  $items
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildTree(array $items, ?int $parentId): array
+    {
+        $nodes = [];
+
+        foreach ($items as $item) {
+            if ($item->parent_id !== $parentId) {
+                continue;
+            }
+
+            $nodes[] = [
+                'label' => $item->label,
+                'url' => $item->url,
+                'children' => $this->buildTree($items, $item->id),
+            ];
+        }
+
+        return $nodes;
+    }
+}

--- a/packages/liberu-cms/cms-menus/src/MenusServiceProvider.php
+++ b/packages/liberu-cms/cms-menus/src/MenusServiceProvider.php
@@ -7,11 +7,14 @@ namespace Liberu\Cms\Menus;
 use Liberu\Cms\Contracts\Admin\AdminDashboardRegistryInterface;
 use Liberu\Cms\Contracts\Admin\AdminResourceRegistryInterface;
 use Liberu\Cms\Contracts\Admin\DashboardStat;
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Menus\Contracts\MenuRepositoryInterface;
 use Liberu\Cms\Menus\Filament\MenuItemResource;
 use Liberu\Cms\Menus\Filament\MenuResource;
+use Liberu\Cms\Menus\Http\Controllers\MenuApiController;
 use Liberu\Cms\Menus\Models\Menu;
 use Liberu\Cms\Menus\Repositories\MenuRepository;
 
@@ -30,6 +33,13 @@ final class MenusServiceProvider extends ModuleServiceProvider
             $registry = $this->app->make(AdminResourceRegistryInterface::class);
             $registry->registerResource('menus', MenuResource::class);
             $registry->registerResource('menus', MenuItemResource::class);
+        }
+
+        if ($this->app->bound(ApiResourceRegistryInterface::class)) {
+            $this->app->make(ApiResourceRegistryInterface::class)->registerEndpoint(
+                'menus',
+                new ApiEndpoint('menus/{location}', MenuApiController::class, 'show', 'menus.show'),
+            );
         }
     }
 

--- a/packages/liberu-cms/cms-pages/src/Http/Controllers/PageApiController.php
+++ b/packages/liberu-cms/cms-pages/src/Http/Controllers/PageApiController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Http\Controllers;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Liberu\Cms\Core\Support\ApiPagination;
+use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
+use Liberu\Cms\Pages\Http\Resources\PageResource;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Serves published Pages over the Delivery API. Reads go through the Pages
+ * repository; the tenant global scope (driven by the request tenant context)
+ * restricts every query to the token's Team, so a cross-tenant slug is simply
+ * not found.
+ */
+final readonly class PageApiController
+{
+    public function __construct(private PageRepositoryInterface $pages) {}
+
+    public function index(): AnonymousResourceCollection
+    {
+        return PageResource::collection(ApiPagination::fromArray($this->pages->published()));
+    }
+
+    public function show(string $slug): PageResource
+    {
+        $page = $this->pages->findBySlug($slug);
+
+        if ($page === null || ! $page->isLive()) {
+            throw new NotFoundHttpException;
+        }
+
+        return new PageResource($page);
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/Http/Resources/PageResource.php
+++ b/packages/liberu-cms/cms-pages/src/Http/Resources/PageResource.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\Cms\Content\Support\HtmlSanitizer;
+use Liberu\Cms\Core\Http\Concerns\EmbedsFeaturedMedia;
+use Liberu\Cms\Pages\Models\Page;
+
+/**
+ * The Delivery API wire shape for a Page. Internal columns (team_id, workflow
+ * internals, timestamps) are omitted; `content` is sanitised HTML and the
+ * featured image is embedded as URL + alt text.
+ *
+ * @mixin Page
+ */
+final class PageResource extends JsonResource
+{
+    use EmbedsFeaturedMedia;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'template' => $this->template,
+            'excerpt' => $this->excerpt,
+            'content' => app(HtmlSanitizer::class)->sanitize($this->content),
+            'featured_media' => $this->featuredMediaPayload($this->featuredMedia()),
+            'published_at' => $this->publishedAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
+++ b/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
@@ -7,10 +7,13 @@ namespace Liberu\Cms\Pages;
 use Liberu\Cms\Contracts\Admin\AdminDashboardRegistryInterface;
 use Liberu\Cms\Contracts\Admin\AdminResourceRegistryInterface;
 use Liberu\Cms\Contracts\Admin\DashboardStat;
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
 use Liberu\Cms\Pages\Filament\PageResource;
+use Liberu\Cms\Pages\Http\Controllers\PageApiController;
 use Liberu\Cms\Pages\Models\Page;
 use Liberu\Cms\Pages\Repositories\PageRepository;
 
@@ -29,6 +32,12 @@ final class PagesServiceProvider extends ModuleServiceProvider
 
         if ($this->app->bound(AdminResourceRegistryInterface::class)) {
             $this->app->make(AdminResourceRegistryInterface::class)->registerResource('pages', PageResource::class);
+        }
+
+        if ($this->app->bound(ApiResourceRegistryInterface::class)) {
+            $registry = $this->app->make(ApiResourceRegistryInterface::class);
+            $registry->registerEndpoint('pages', new ApiEndpoint('pages', PageApiController::class, 'index', 'pages.index'));
+            $registry->registerEndpoint('pages', new ApiEndpoint('pages/{slug}', PageApiController::class, 'show', 'pages.show'));
         }
     }
 

--- a/packages/liberu-cms/cms-posts/src/Http/Controllers/PostApiController.php
+++ b/packages/liberu-cms/cms-posts/src/Http/Controllers/PostApiController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Http\Controllers;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Liberu\Cms\Core\Support\ApiPagination;
+use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
+use Liberu\Cms\Posts\Http\Resources\PostResource;
+use Liberu\Cms\Posts\Models\Post;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Serves published Posts over the Delivery API, newest first, optionally
+ * filtered by a category or tag slug. The tenant global scope restricts every
+ * query to the token's Team.
+ */
+final readonly class PostApiController
+{
+    public function __construct(private PostRepositoryInterface $posts) {}
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $category = $request->query('category');
+        $tag = $request->query('tag');
+
+        $posts = match (true) {
+            is_string($category) && $category !== '' => $this->posts->byCategory($category),
+            is_string($tag) && $tag !== '' => $this->posts->byTag($tag),
+            default => $this->posts->published(),
+        };
+
+        $posts = (new Collection($posts))->loadMissing(['categories', 'tags']);
+
+        return PostResource::collection(ApiPagination::fromArray($posts->all()));
+    }
+
+    public function show(string $slug): PostResource
+    {
+        $post = $this->posts->findBySlug($slug);
+
+        if (! $post instanceof Post || ! $post->isLive()) {
+            throw new NotFoundHttpException;
+        }
+
+        $post->loadMissing(['categories', 'tags']);
+
+        return new PostResource($post);
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/Http/Resources/PostResource.php
+++ b/packages/liberu-cms/cms-posts/src/Http/Resources/PostResource.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\Cms\Content\Support\HtmlSanitizer;
+use Liberu\Cms\Core\Http\Concerns\EmbedsFeaturedMedia;
+use Liberu\Cms\Posts\Models\Category;
+use Liberu\Cms\Posts\Models\Post;
+use Liberu\Cms\Posts\Models\Tag;
+
+/**
+ * The Delivery API wire shape for a Post: sanitised HTML content, an embedded
+ * featured image (URL + alt), and inline categories and tags so a consumer can
+ * render taxonomy links without extra requests.
+ *
+ * @mixin Post
+ */
+final class PostResource extends JsonResource
+{
+    use EmbedsFeaturedMedia;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'content' => app(HtmlSanitizer::class)->sanitize($this->content),
+            'featured_media' => $this->featuredMediaPayload($this->featuredMedia()),
+            'categories' => $this->categories->map(fn (Category $category): array => [
+                'name' => $category->name,
+                'slug' => $category->slug,
+            ])->values()->all(),
+            'tags' => $this->tags->map(fn (Tag $tag): array => [
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+            ])->values()->all(),
+            'published_at' => $this->publishedAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
+++ b/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
@@ -7,10 +7,13 @@ namespace Liberu\Cms\Posts;
 use Liberu\Cms\Contracts\Admin\AdminDashboardRegistryInterface;
 use Liberu\Cms\Contracts\Admin\AdminResourceRegistryInterface;
 use Liberu\Cms\Contracts\Admin\DashboardStat;
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
 use Liberu\Cms\Posts\Filament\PostResource;
+use Liberu\Cms\Posts\Http\Controllers\PostApiController;
 use Liberu\Cms\Posts\Models\Post;
 use Liberu\Cms\Posts\Repositories\PostRepository;
 
@@ -29,6 +32,12 @@ final class PostsServiceProvider extends ModuleServiceProvider
 
         if ($this->app->bound(AdminResourceRegistryInterface::class)) {
             $this->app->make(AdminResourceRegistryInterface::class)->registerResource('posts', PostResource::class);
+        }
+
+        if ($this->app->bound(ApiResourceRegistryInterface::class)) {
+            $registry = $this->app->make(ApiResourceRegistryInterface::class);
+            $registry->registerEndpoint('posts', new ApiEndpoint('posts', PostApiController::class, 'index', 'posts.index'));
+            $registry->registerEndpoint('posts', new ApiEndpoint('posts/{slug}', PostApiController::class, 'show', 'posts.show'));
         }
     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
     level: max
     paths:
         - packages/liberu-cms/cms-admin/src
+        - packages/liberu-cms/cms-api/src
         - packages/liberu-cms/cms-blocks/src
         - packages/liberu-cms/cms-content/src
         - packages/liberu-cms/cms-content-types/src

--- a/tests/Feature/Api/ContentEntriesApiTest.php
+++ b/tests/Feature/Api/ContentEntriesApiTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\ContentTypes\Models\ContentEntry;
+use Liberu\Cms\ContentTypes\Models\ContentType;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    $this->type = ContentType::factory()->create(['key' => 'portfolio']);
+});
+
+it('returns published entries of a given type', function (): void {
+    ContentEntry::factory()->published()->create(['team_id' => $this->teamA->id, 'content_type_id' => $this->type->id, 'slug' => 'live-item']);
+    ContentEntry::factory()->create(['team_id' => $this->teamA->id, 'content_type_id' => $this->type->id, 'slug' => 'draft-item']);
+
+    $this->getJson('/api/v1/content/portfolio')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'live-item')
+        ->assertJsonMissing(['slug' => 'draft-item']);
+});
+
+it('fetches a single entry by slug with its typed fields', function (): void {
+    ContentEntry::factory()->published()->create([
+        'team_id' => $this->teamA->id,
+        'content_type_id' => $this->type->id,
+        'slug' => 'case-study',
+        'data' => ['summary' => 'A great project', 'year' => 2026],
+    ]);
+
+    $this->getJson('/api/v1/content/portfolio/case-study')
+        ->assertOk()
+        ->assertJsonPath('data.type', 'portfolio')
+        ->assertJsonPath('data.fields.summary', 'A great project')
+        ->assertJsonPath('data.fields.year', 2026);
+});
+
+it('returns 404 for a draft entry, an unknown slug, and a mismatched type', function (): void {
+    ContentEntry::factory()->create(['team_id' => $this->teamA->id, 'content_type_id' => $this->type->id, 'slug' => 'hidden']);
+    $other = ContentType::factory()->create(['key' => 'product']);
+    ContentEntry::factory()->published()->create(['team_id' => $this->teamA->id, 'content_type_id' => $other->id, 'slug' => 'a-product']);
+
+    $this->getJson('/api/v1/content/portfolio/hidden')->assertNotFound();
+    $this->getJson('/api/v1/content/portfolio/ghost')->assertNotFound();
+    $this->getJson('/api/v1/content/portfolio/a-product')->assertNotFound();
+});
+
+it('does not leak another tenant\'s entry', function (): void {
+    ContentEntry::factory()->published()->create(['team_id' => $this->teamB->id, 'content_type_id' => $this->type->id, 'slug' => 'team-b-entry']);
+
+    $this->getJson('/api/v1/content/portfolio/team-b-entry')->assertNotFound();
+    $this->getJson('/api/v1/content/portfolio')->assertOk()->assertJsonCount(0, 'data');
+});

--- a/tests/Feature/Api/DeliveryAuthTest.php
+++ b/tests/Feature/Api/DeliveryAuthTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Pages\Models\Page;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config()->set('permission.teams', true);
+});
+
+it('authenticates with a bearer Delivery token and scopes to its team', function (): void {
+    $team = Team::factory()->create();
+    Page::factory()->published()->create(['team_id' => $team->id, 'slug' => 'welcome']);
+
+    $token = $team->createToken('delivery', ['content:read'])->plainTextToken;
+
+    $this->withToken($token)
+        ->getJson('/api/v1/pages/welcome')
+        ->assertOk()
+        ->assertJsonPath('data.slug', 'welcome');
+});
+
+it('issues a Delivery token from the console command', function (): void {
+    $team = Team::factory()->create();
+
+    $this->artisan('cms-api:issue-token', ['team' => $team->id])
+        ->assertSuccessful();
+
+    expect($team->tokens()->count())->toBe(1);
+});
+
+it('fails the token command for an unknown team', function (): void {
+    $this->artisan('cms-api:issue-token', ['team' => 999999])
+        ->assertFailed();
+});
+
+it('rate limits per token with a 429 and Retry-After header', function (): void {
+    config()->set('cms-api.rate_limit', 1);
+
+    $team = Team::factory()->create();
+    Page::factory()->published()->create(['team_id' => $team->id, 'slug' => 'welcome']);
+    $token = $team->createToken('delivery', ['content:read'])->plainTextToken;
+
+    $this->withToken($token)->getJson('/api/v1/pages')->assertOk();
+
+    $this->withToken($token)->getJson('/api/v1/pages')
+        ->assertStatus(429)
+        ->assertHeader('Retry-After');
+});

--- a/tests/Feature/Api/MenusApiTest.php
+++ b/tests/Feature/Api/MenusApiTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Menus\Models\Menu;
+use Liberu\Cms\Menus\Models\MenuItem;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+});
+
+it('fetches a menu by location with its ordered, nested item tree', function (): void {
+    $menu = Menu::factory()->create(['team_id' => $this->teamA->id, 'name' => 'Main', 'location' => 'header']);
+
+    $home = MenuItem::factory()->create(['team_id' => $this->teamA->id, 'menu_id' => $menu->id, 'label' => 'Home', 'url' => '/', 'sort' => 0]);
+    $about = MenuItem::factory()->create(['team_id' => $this->teamA->id, 'menu_id' => $menu->id, 'label' => 'About', 'url' => '/about', 'sort' => 1]);
+    MenuItem::factory()->create(['team_id' => $this->teamA->id, 'menu_id' => $menu->id, 'parent_id' => $about->id, 'label' => 'Team', 'url' => '/about/team', 'sort' => 0]);
+
+    $this->getJson('/api/v1/menus/header')
+        ->assertOk()
+        ->assertJsonPath('data.location', 'header')
+        ->assertJsonPath('data.items.0.label', 'Home')
+        ->assertJsonPath('data.items.1.label', 'About')
+        ->assertJsonPath('data.items.1.children.0.label', 'Team');
+});
+
+it('returns 404 for an unknown location', function (): void {
+    $this->getJson('/api/v1/menus/footer')->assertNotFound();
+});
+
+it('does not leak another tenant\'s menu', function (): void {
+    Menu::factory()->create(['team_id' => $this->teamB->id, 'location' => 'sidebar']);
+
+    $this->getJson('/api/v1/menus/sidebar')->assertNotFound();
+});

--- a/tests/Feature/Api/PagesApiTest.php
+++ b/tests/Feature/Api/PagesApiTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Pages\Models\Page;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+});
+
+function actAsDeliveryClient(Team $team): void
+{
+    Sanctum::actingAs($team, ['content:read'], 'sanctum');
+}
+
+it('rejects an unauthenticated request with 401', function (): void {
+    $this->getJson('/api/v1/pages')->assertUnauthorized();
+});
+
+it('rejects an unauthenticated non-JSON request with 401 rather than a redirect', function (): void {
+    $this->get('/api/v1/pages')->assertUnauthorized();
+});
+
+it('enables CORS for the API paths', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    $this->getJson('/api/v1/pages', ['Origin' => 'https://frontend.example'])
+        ->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', '*');
+});
+
+it('returns published pages for the token\'s tenant', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Live One', 'slug' => 'live-one']);
+    Page::factory()->create(['team_id' => $this->teamA->id, 'title' => 'A Draft', 'slug' => 'a-draft']);
+
+    $response = $this->getJson('/api/v1/pages');
+
+    $response->assertOk()
+        ->assertJsonPath('data.0.slug', 'live-one')
+        ->assertJsonMissing(['slug' => 'a-draft'])
+        ->assertJsonCount(1, 'data');
+});
+
+it('fetches a single published page by slug', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'About', 'slug' => 'about']);
+
+    $this->getJson('/api/v1/pages/about')
+        ->assertOk()
+        ->assertJsonPath('data.slug', 'about')
+        ->assertJsonPath('data.title', 'About');
+});
+
+it('returns 404 for a draft page fetched by slug', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'secret-draft']);
+
+    $this->getJson('/api/v1/pages/secret-draft')->assertNotFound();
+});
+
+it('returns 404 for an unknown slug', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    $this->getJson('/api/v1/pages/nope')->assertNotFound();
+});
+
+it('does not leak another tenant\'s page (cross-tenant is 404)', function (): void {
+    Page::factory()->published()->create(['team_id' => $this->teamB->id, 'slug' => 'team-b-page']);
+
+    actAsDeliveryClient($this->teamA);
+
+    $this->getJson('/api/v1/pages/team-b-page')->assertNotFound();
+    $this->getJson('/api/v1/pages')->assertOk()->assertJsonCount(0, 'data');
+});
+
+it('returns content as sanitized HTML', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->published()->create([
+        'team_id' => $this->teamA->id,
+        'slug' => 'xss',
+        'content' => '<p>Visible safe text</p><script>alert("pwned")</script><p onclick="steal()">handler text</p>',
+    ]);
+
+    $response = $this->getJson('/api/v1/pages/xss');
+
+    $content = $response->json('data.content');
+
+    expect($content)
+        ->toContain('Visible safe text')
+        ->toContain('handler text')
+        ->not->toContain('alert("pwned")')
+        ->not->toContain('onclick')
+        ->not->toContain('steal()');
+});
+
+it('paginates with consistent metadata and honors per_page', function (): void {
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->published()->count(20)->create(['team_id' => $this->teamA->id]);
+
+    $response = $this->getJson('/api/v1/pages?per_page=5');
+
+    $response->assertOk()
+        ->assertJsonCount(5, 'data')
+        ->assertJsonPath('meta.per_page', 5)
+        ->assertJsonPath('meta.total', 20)
+        ->assertJsonStructure(['data', 'links', 'meta' => ['current_page', 'per_page', 'total']]);
+});
+
+it('caps per_page at the configured maximum', function (): void {
+    config()->set('cms-api.pagination.max', 100);
+    actAsDeliveryClient($this->teamA);
+
+    Page::factory()->published()->count(3)->create(['team_id' => $this->teamA->id]);
+
+    $this->getJson('/api/v1/pages?per_page=1000')
+        ->assertOk()
+        ->assertJsonPath('meta.per_page', 100);
+});

--- a/tests/Feature/Api/PostsApiTest.php
+++ b/tests/Feature/Api/PostsApiTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Posts\Models\Category;
+use Liberu\Cms\Posts\Models\Post;
+use Liberu\Cms\Posts\Models\Tag;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+});
+
+it('returns published posts newest first and hides drafts', function (): void {
+    $older = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'older', 'published_at' => now()->subDay()]);
+    $newer = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'newer', 'published_at' => now()]);
+    Post::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'draft']);
+
+    $this->getJson('/api/v1/posts')
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('data.0.slug', 'newer')
+        ->assertJsonPath('data.1.slug', 'older')
+        ->assertJsonMissing(['slug' => 'draft']);
+});
+
+it('fetches a single published post with categories and tags inline', function (): void {
+    $post = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'hello-world']);
+    $category = Category::factory()->create(['team_id' => $this->teamA->id, 'name' => 'News', 'slug' => 'news']);
+    $tag = Tag::factory()->create(['team_id' => $this->teamA->id, 'name' => 'Laravel', 'slug' => 'laravel']);
+    $post->categories()->attach($category);
+    $post->tags()->attach($tag);
+
+    $this->getJson('/api/v1/posts/hello-world')
+        ->assertOk()
+        ->assertJsonPath('data.slug', 'hello-world')
+        ->assertJsonPath('data.categories.0.slug', 'news')
+        ->assertJsonPath('data.tags.0.slug', 'laravel')
+        ->assertJsonMissingPath('data.team_id');
+});
+
+it('returns 404 for a draft post and for an unknown slug', function (): void {
+    Post::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'not-live']);
+
+    $this->getJson('/api/v1/posts/not-live')->assertNotFound();
+    $this->getJson('/api/v1/posts/ghost')->assertNotFound();
+});
+
+it('does not leak another tenant\'s post', function (): void {
+    Post::factory()->published()->create(['team_id' => $this->teamB->id, 'slug' => 'team-b-post']);
+
+    $this->getJson('/api/v1/posts/team-b-post')->assertNotFound();
+    $this->getJson('/api/v1/posts')->assertOk()->assertJsonCount(0, 'data');
+});
+
+it('filters posts by category slug', function (): void {
+    $inCategory = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'in-cat']);
+    $outCategory = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'out-cat']);
+    $category = Category::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'tech']);
+    $inCategory->categories()->attach($category);
+
+    $this->getJson('/api/v1/posts?category=tech')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'in-cat');
+});
+
+it('filters posts by tag slug', function (): void {
+    $tagged = Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'tagged']);
+    Post::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'untagged']);
+    $tag = Tag::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'php']);
+    $tagged->tags()->attach($tag);
+
+    $this->getJson('/api/v1/posts?tag=php')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.slug', 'tagged');
+});


### PR DESCRIPTION
Introduce a versioned (/api/v1), read-only, Sanctum-authenticated JSON API
that serves published content to decoupled frontends.

New cms-api package owns the infrastructure: the route group, Delivery-token
auth (Sanctum tokens whose tokenable is a Team), the request tenant context,
per-token rate limiting (429 + Retry-After), CORS for api/v1/*, JSON error
handling, and the cms-api:issue-token command. Content modules contribute
their endpoints + Eloquent Resources through the new ApiResourceRegistry
(mirroring the Phase 4 admin registry), so the API package never imports a
module and headless subsets stay safe via app()->bound() guards.

Tenancy: a request-scoped TenantContext (set from the token's Team) drives a
TenantScope global scope on tenant models, isolating API reads without a second
manual filter. Inside the Filament panel the context is empty, so the panel's
own tenancy scope remains the single mechanism there. Host Team gains
HasApiTokens + Authenticatable; the tenancy resolver reads the API context
first.

Endpoints: Pages, Posts (+category/tag filters, inline taxonomy + featured
media), Menus (ordered nested tree by location), Content-Entries (typed
fields). content is returned sanitized via HtmlSanitizer; collections paginate
with a capped per_page.