### PR TITLE
Phase 5 (3/n): cms-search — full-text search on the Delivery API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "liberu-cms/cms-menus": "*",
         "liberu-cms/cms-pages": "*",
         "liberu-cms/cms-posts": "*",
+        "liberu-cms/cms-search": "*",
         "liberu-cms/cms-seo": "*",
         "liberu-cms/cms-themes": "*",
         "liberu-cms/cms-users": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f024b89002a52d549fb31694582453cb",
+    "content-hash": "cbeda18e9c99ada58a062cae4c16dbc8",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6140,6 +6140,49 @@
                 "MIT"
             ],
             "description": "Posts module for Liberu CMS: blog posts with taxonomy (categories & tags), workflow, versioning, and featured media.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-search",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-search",
+                "reference": "ad8ebf9b268ae77eb7d4b749d96a488bd2c10b7d"
+            },
+            "require": {
+                "illuminate/contracts": "^13.0",
+                "illuminate/http": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Search\\CmsSearchServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Search\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Search\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Search module for Liberu CMS: full-text search over published content across every content type, exposed on the Delivery API.",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
+++ b/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
@@ -11,12 +11,14 @@ use Liberu\Cms\ContentTypes\Http\Controllers\ContentEntryApiController;
 use Liberu\Cms\ContentTypes\Models\ContentEntry;
 use Liberu\Cms\ContentTypes\Repositories\ContentEntryRepository;
 use Liberu\Cms\ContentTypes\Schema\SchemaValidator;
+use Liberu\Cms\ContentTypes\Search\ContentEntrySearchSource;
 use Liberu\Cms\Contracts\Admin\AdminDashboardRegistryInterface;
 use Liberu\Cms\Contracts\Admin\AdminResourceRegistryInterface;
 use Liberu\Cms\Contracts\Admin\DashboardStat;
 use Liberu\Cms\Contracts\Api\ApiEndpoint;
 use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 
 final class ContentTypesServiceProvider extends ModuleServiceProvider
@@ -52,6 +54,11 @@ final class ContentTypesServiceProvider extends ModuleServiceProvider
             $this->app->make(AdminDashboardRegistryInterface::class)->registerStat(
                 new DashboardStat('Content entries', fn (): int => ContentEntry::count(), 'heroicon-o-rectangle-stack', 'primary'),
             );
+        }
+
+        if ($this->app->bound(SearchRegistryInterface::class)) {
+            $this->app->make(SearchRegistryInterface::class)
+                ->registerSource($this->app->make(ContentEntrySearchSource::class));
         }
     }
 }

--- a/packages/liberu-cms/cms-content-types/src/Contracts/ContentEntryRepositoryInterface.php
+++ b/packages/liberu-cms/cms-content-types/src/Contracts/ContentEntryRepositoryInterface.php
@@ -28,4 +28,11 @@ interface ContentEntryRepositoryInterface
      * @return array<int, ContentEntry>
      */
     public function published(): array;
+
+    /**
+     * Live entries whose title or field data matches the query.
+     *
+     * @return array<int, ContentEntry>
+     */
+    public function search(string $query, int $limit): array;
 }

--- a/packages/liberu-cms/cms-content-types/src/Repositories/ContentEntryRepository.php
+++ b/packages/liberu-cms/cms-content-types/src/Repositories/ContentEntryRepository.php
@@ -40,4 +40,22 @@ final class ContentEntryRepository implements ContentEntryRepositoryInterface
             ->get()
             ->all();
     }
+
+    public function search(string $query, int $limit): array
+    {
+        $like = '%'.addcslashes($query, '%_\\').'%';
+
+        return ContentEntry::query()
+            ->where('status', WorkflowState::Published->value)
+            ->where(function (Builder $inner): void {
+                $inner->whereNull('published_at')->orWhere('published_at', '<=', now());
+            })
+            ->where(function (Builder $inner) use ($like): void {
+                $inner->where('title', 'like', $like)
+                    ->orWhere('data', 'like', $like);
+            })
+            ->limit($limit)
+            ->get()
+            ->all();
+    }
 }

--- a/packages/liberu-cms/cms-content-types/src/Search/ContentEntrySearchSource.php
+++ b/packages/liberu-cms/cms-content-types/src/Search/ContentEntrySearchSource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Search;
+
+use Illuminate\Database\Eloquent\Collection;
+use Liberu\Cms\ContentTypes\Contracts\ContentEntryRepositoryInterface;
+use Liberu\Cms\ContentTypes\Models\ContentType;
+use Liberu\Cms\Contracts\Search\SearchableSourceInterface;
+use Liberu\Cms\Contracts\Search\SearchResult;
+use Liberu\Cms\Core\Support\SearchScoring;
+
+/**
+ * Searches published Content-Entries for the Delivery API search endpoint. The
+ * result `type` is the entry's content-type key so the consumer can build the
+ * `/content/{type}/{slug}` link.
+ */
+final readonly class ContentEntrySearchSource implements SearchableSourceInterface
+{
+    public function __construct(private ContentEntryRepositoryInterface $entries) {}
+
+    public function search(string $query): iterable
+    {
+        $entries = new Collection($this->entries->search($query, SearchScoring::perSourceLimit()));
+        $entries->loadMissing('type');
+
+        foreach ($entries as $entry) {
+            $type = $entry->type;
+
+            yield new SearchResult(
+                type: $type instanceof ContentType ? $type->key : 'content-entry',
+                id: $entry->id,
+                title: $entry->title,
+                slug: $entry->slug,
+                excerpt: null,
+                score: SearchScoring::score($entry->title, $query),
+            );
+        }
+    }
+}

--- a/packages/liberu-cms/cms-contracts/src/Search/SearchRegistryInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Search/SearchRegistryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Search;
+
+/**
+ * The catalogue of searchable sources modules contribute. A module announces its
+ * source; the search module reads the catalogue to query every content type — so
+ * search tracks the installed modules without importing one. Mirrors the admin,
+ * API, and sitemap registries.
+ */
+interface SearchRegistryInterface
+{
+    public function registerSource(SearchableSourceInterface $source): void;
+
+    /**
+     * @return array<int, SearchableSourceInterface>
+     */
+    public function sources(): array;
+}

--- a/packages/liberu-cms/cms-contracts/src/Search/SearchResult.php
+++ b/packages/liberu-cms/cms-contracts/src/Search/SearchResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Search;
+
+/**
+ * A single normalized search hit. Content modules build these from their own
+ * models so the search module can rank and serialize results across every
+ * content type without knowing any concrete class. The consumer maps `type` +
+ * `slug` to its own route.
+ */
+final class SearchResult
+{
+    public function __construct(
+        public string $type,
+        public int|string $id,
+        public string $title,
+        public string $slug,
+        public ?string $excerpt = null,
+        public float $score = 1.0,
+    ) {}
+}

--- a/packages/liberu-cms/cms-contracts/src/Search/SearchableSourceInterface.php
+++ b/packages/liberu-cms/cms-contracts/src/Search/SearchableSourceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Search;
+
+/**
+ * A content type that can be searched. Each content module implements this for
+ * its own model and registers it with the search registry, so the search module
+ * queries every content type without ever importing a module. Implementations
+ * must return only published content; tenant scoping is applied by the shared
+ * tenancy scope during the request.
+ */
+interface SearchableSourceInterface
+{
+    /**
+     * Published items matching the query, as normalized results.
+     *
+     * @return iterable<int, SearchResult>
+     */
+    public function search(string $query): iterable;
+}

--- a/packages/liberu-cms/cms-core/src/Support/SearchScoring.php
+++ b/packages/liberu-cms/cms-core/src/Support/SearchScoring.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Support;
+
+/**
+ * Shared helpers for the Delivery API search sources: the per-source row cap and
+ * a simple relevance score that ranks a title match above a body-only match.
+ * Kept in one place so every content source ranks consistently.
+ *
+ * @internal Used by content modules' search sources.
+ */
+final class SearchScoring
+{
+    public static function perSourceLimit(): int
+    {
+        $limit = config('cms-search.per_source_limit', 50);
+
+        return is_numeric($limit) ? max(1, (int) $limit) : 50;
+    }
+
+    /**
+     * 2.0 when the query appears in the title, otherwise 1.0 (a body-only match).
+     */
+    public static function score(string $title, string $query): float
+    {
+        return stripos($title, $query) !== false ? 2.0 : 1.0;
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/Contracts/PageRepositoryInterface.php
+++ b/packages/liberu-cms/cms-pages/src/Contracts/PageRepositoryInterface.php
@@ -29,4 +29,11 @@ interface PageRepositoryInterface
      * @return array<int, Page>
      */
     public function roots(): array;
+
+    /**
+     * Live pages whose title or body matches the query.
+     *
+     * @return array<int, Page>
+     */
+    public function search(string $query, int $limit): array;
 }

--- a/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
+++ b/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
@@ -10,6 +10,7 @@ use Liberu\Cms\Contracts\Admin\DashboardStat;
 use Liberu\Cms\Contracts\Api\ApiEndpoint;
 use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
 use Liberu\Cms\Contracts\Seo\SitemapRegistryInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
@@ -17,6 +18,7 @@ use Liberu\Cms\Pages\Filament\PageResource;
 use Liberu\Cms\Pages\Http\Controllers\PageApiController;
 use Liberu\Cms\Pages\Models\Page;
 use Liberu\Cms\Pages\Repositories\PageRepository;
+use Liberu\Cms\Pages\Search\PageSearchSource;
 use Liberu\Cms\Pages\Seo\PageSitemapProvider;
 
 final class PagesServiceProvider extends ModuleServiceProvider
@@ -56,6 +58,11 @@ final class PagesServiceProvider extends ModuleServiceProvider
         if ($this->app->bound(SitemapRegistryInterface::class)) {
             $this->app->make(SitemapRegistryInterface::class)
                 ->registerProvider($this->app->make(PageSitemapProvider::class));
+        }
+
+        if ($this->app->bound(SearchRegistryInterface::class)) {
+            $this->app->make(SearchRegistryInterface::class)
+                ->registerSource($this->app->make(PageSearchSource::class));
         }
 
         if ($this->app->runningInConsole()) {

--- a/packages/liberu-cms/cms-pages/src/Repositories/PageRepository.php
+++ b/packages/liberu-cms/cms-pages/src/Repositories/PageRepository.php
@@ -41,4 +41,23 @@ final class PageRepository implements PageRepositoryInterface
             ->get()
             ->all();
     }
+
+    public function search(string $query, int $limit): array
+    {
+        $like = '%'.addcslashes($query, '%_\\').'%';
+
+        return Page::query()
+            ->where('status', WorkflowState::Published->value)
+            ->where(function (Builder $inner): void {
+                $inner->whereNull('published_at')->orWhere('published_at', '<=', now());
+            })
+            ->where(function (Builder $inner) use ($like): void {
+                $inner->where('title', 'like', $like)
+                    ->orWhere('content', 'like', $like)
+                    ->orWhere('excerpt', 'like', $like);
+            })
+            ->limit($limit)
+            ->get()
+            ->all();
+    }
 }

--- a/packages/liberu-cms/cms-pages/src/Search/PageSearchSource.php
+++ b/packages/liberu-cms/cms-pages/src/Search/PageSearchSource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Search;
+
+use Liberu\Cms\Contracts\Search\SearchableSourceInterface;
+use Liberu\Cms\Contracts\Search\SearchResult;
+use Liberu\Cms\Core\Support\SearchScoring;
+use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
+
+/**
+ * Searches published Pages for the Delivery API search endpoint.
+ */
+final readonly class PageSearchSource implements SearchableSourceInterface
+{
+    public function __construct(private PageRepositoryInterface $pages) {}
+
+    public function search(string $query): iterable
+    {
+        foreach ($this->pages->search($query, SearchScoring::perSourceLimit()) as $page) {
+            yield new SearchResult(
+                type: 'page',
+                id: $page->id,
+                title: $page->title,
+                slug: $page->slug,
+                excerpt: $page->excerpt,
+                score: SearchScoring::score($page->title, $query),
+            );
+        }
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/Contracts/PostRepositoryInterface.php
+++ b/packages/liberu-cms/cms-posts/src/Contracts/PostRepositoryInterface.php
@@ -43,4 +43,11 @@ interface PostRepositoryInterface
      * @return array<int, Post>
      */
     public function byTag(string $tagSlug): array;
+
+    /**
+     * Live posts whose title or body matches the query.
+     *
+     * @return array<int, Post>
+     */
+    public function search(string $query, int $limit): array;
 }

--- a/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
+++ b/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
@@ -10,12 +10,14 @@ use Liberu\Cms\Contracts\Admin\DashboardStat;
 use Liberu\Cms\Contracts\Api\ApiEndpoint;
 use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
 use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
 use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
 use Liberu\Cms\Posts\Filament\PostResource;
 use Liberu\Cms\Posts\Http\Controllers\PostApiController;
 use Liberu\Cms\Posts\Models\Post;
 use Liberu\Cms\Posts\Repositories\PostRepository;
+use Liberu\Cms\Posts\Search\PostSearchSource;
 
 final class PostsServiceProvider extends ModuleServiceProvider
 {
@@ -49,6 +51,11 @@ final class PostsServiceProvider extends ModuleServiceProvider
             $this->app->make(AdminDashboardRegistryInterface::class)->registerStat(
                 new DashboardStat('Posts', fn (): int => Post::count(), 'heroicon-o-newspaper', 'primary'),
             );
+        }
+
+        if ($this->app->bound(SearchRegistryInterface::class)) {
+            $this->app->make(SearchRegistryInterface::class)
+                ->registerSource($this->app->make(PostSearchSource::class));
         }
 
         if ($this->app->runningInConsole()) {

--- a/packages/liberu-cms/cms-posts/src/Repositories/PostRepository.php
+++ b/packages/liberu-cms/cms-posts/src/Repositories/PostRepository.php
@@ -47,6 +47,21 @@ final class PostRepository implements PostRepositoryInterface
             ->all();
     }
 
+    public function search(string $query, int $limit): array
+    {
+        $like = '%'.addcslashes($query, '%_\\').'%';
+
+        return $this->live()
+            ->where(function (Builder $inner) use ($like): void {
+                $inner->where('title', 'like', $like)
+                    ->orWhere('content', 'like', $like)
+                    ->orWhere('excerpt', 'like', $like);
+            })
+            ->limit($limit)
+            ->get()
+            ->all();
+    }
+
     /**
      * @return Builder<Post>
      */

--- a/packages/liberu-cms/cms-posts/src/Search/PostSearchSource.php
+++ b/packages/liberu-cms/cms-posts/src/Search/PostSearchSource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Search;
+
+use Liberu\Cms\Contracts\Search\SearchableSourceInterface;
+use Liberu\Cms\Contracts\Search\SearchResult;
+use Liberu\Cms\Core\Support\SearchScoring;
+use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
+
+/**
+ * Searches published Posts for the Delivery API search endpoint.
+ */
+final readonly class PostSearchSource implements SearchableSourceInterface
+{
+    public function __construct(private PostRepositoryInterface $posts) {}
+
+    public function search(string $query): iterable
+    {
+        foreach ($this->posts->search($query, SearchScoring::perSourceLimit()) as $post) {
+            yield new SearchResult(
+                type: 'post',
+                id: $post->id,
+                title: $post->title,
+                slug: $post->slug,
+                excerpt: $post->excerpt,
+                score: SearchScoring::score($post->title, $query),
+            );
+        }
+    }
+}

--- a/packages/liberu-cms/cms-search/README.md
+++ b/packages/liberu-cms/cms-search/README.md
@@ -1,0 +1,55 @@
+# CMS Search
+
+Full-text search over **published** content, exposed on the Delivery API. The
+search module aggregates results from every content module that registers a
+`SearchableSourceInterface`, so it never imports a module (same pattern as the
+admin, API, and sitemap registries).
+
+## Endpoint
+
+```
+GET /api/v1/search?q=<terms>&per_page=<n>
+```
+
+Registered into the Delivery API route group, so it inherits the same auth
+(Delivery token), tenant scoping, and rate limiting. Results are scoped to the
+token's Team and to published content, merged across content types, ranked by
+score (highest first), and paginated with the standard `data`/`meta`/`links`
+envelope.
+
+- A missing or too-short `q` returns `422` (minimum length from
+  `config('cms-search.min_query_length')`).
+- Each source returns at most `config('cms-search.per_source_limit')` rows before
+  ranking.
+
+### Result shape
+
+```json
+{
+  "data": [
+    { "type": "page", "id": 12, "title": "About", "slug": "about", "excerpt": "…", "score": 2.0 }
+  ],
+  "meta": { "current_page": 1, "per_page": 15, "total": 1 },
+  "links": {}
+}
+```
+
+`type` + `slug` let the consumer build its own link to the underlying content.
+
+## Adding a searchable content type
+
+A content module registers a source in its `bootModule()` (boot phase, because
+the search module's registry binds after the content modules load):
+
+```php
+if ($this->app->bound(SearchRegistryInterface::class)) {
+    $this->app->make(SearchRegistryInterface::class)
+        ->registerSource($this->app->make(PageSearchSource::class));
+}
+```
+
+## Driver
+
+v1 uses a database `LIKE` query per source. The `SearchableSourceInterface` seam
+lets a source swap in a dedicated engine (e.g. Laravel Scout) later without
+changing the API.

--- a/packages/liberu-cms/cms-search/composer.json
+++ b/packages/liberu-cms/cms-search/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "liberu-cms/cms-search",
+    "description": "Search module for Liberu CMS: full-text search over published content across every content type, exposed on the Delivery API.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-core": "*",
+        "illuminate/contracts": "^13.0",
+        "illuminate/http": "^13.0",
+        "illuminate/support": "^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Search\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Search\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Search\\CmsSearchServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-search/config/search.php
+++ b/packages/liberu-cms/cms-search/config/search.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Minimum query length
+    |--------------------------------------------------------------------------
+    |
+    | Queries shorter than this are rejected with a 422 to avoid matching
+    | everything on a single character.
+    |
+    */
+
+    'min_query_length' => (int) env('SEARCH_MIN_QUERY_LENGTH', 2),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Per-source limit
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of rows each content source returns before results are
+    | merged and ranked. Bounds the work a single query can do.
+    |
+    */
+
+    'per_source_limit' => (int) env('SEARCH_PER_SOURCE_LIMIT', 50),
+
+];

--- a/packages/liberu-cms/cms-search/src/CmsSearchModule.php
+++ b/packages/liberu-cms/cms-search/src/CmsSearchModule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Search. Adds a full-text search endpoint to the Delivery API, aggregating
+ * results from every content module that registers a searchable source. It
+ * consumes only contracts and the core module system.
+ */
+final class CmsSearchModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'search';
+    }
+
+    public function name(): string
+    {
+        return 'Search';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-search/src/CmsSearchServiceProvider.php
+++ b/packages/liberu-cms/cms-search/src/CmsSearchServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search;
+
+use Liberu\Cms\Contracts\Api\ApiEndpoint;
+use Liberu\Cms\Contracts\Api\ApiResourceRegistryInterface;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+use Liberu\Cms\Search\Http\Controllers\SearchController;
+
+/**
+ * Owns the search surface: it binds the search registry so content modules can
+ * contribute sources, and registers the `/api/v1/search` endpoint into the API
+ * resource registry (cms-api loads first, so the binding is available). The
+ * endpoint therefore inherits the Delivery API's auth, tenant context, and rate
+ * limiting.
+ */
+final class CmsSearchServiceProvider extends ModuleServiceProvider
+{
+    public function module(): ModuleInterface
+    {
+        return new CmsSearchModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/search.php', 'cms-search');
+
+        $this->app->singleton(SearchRegistryInterface::class, SearchRegistry::class);
+
+        if ($this->app->bound(ApiResourceRegistryInterface::class)) {
+            $this->app->make(ApiResourceRegistryInterface::class)->registerEndpoint(
+                'search',
+                new ApiEndpoint('search', SearchController::class, 'index', 'search.index'),
+            );
+        }
+    }
+
+    protected function bootModule(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/search.php' => $this->app->configPath('cms-search.php'),
+            ], 'cms-search-config');
+        }
+    }
+}

--- a/packages/liberu-cms/cms-search/src/Http/Controllers/SearchController.php
+++ b/packages/liberu-cms/cms-search/src/Http/Controllers/SearchController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search\Http\Controllers;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
+use Liberu\Cms\Contracts\Search\SearchResult;
+use Liberu\Cms\Core\Support\ApiPagination;
+use Liberu\Cms\Search\Http\Requests\SearchRequest;
+use Liberu\Cms\Search\Http\Resources\SearchResultResource;
+
+/**
+ * Serves full-text search over published content on the Delivery API. Results
+ * from every registered source are merged, ranked by score (highest first), and
+ * paginated. Each source is tenant-scoped and published-only, so the aggregate
+ * inherits both guarantees.
+ */
+final readonly class SearchController
+{
+    public function __construct(private SearchRegistryInterface $registry) {}
+
+    public function index(SearchRequest $request): AnonymousResourceCollection
+    {
+        $q = $request->validated('q');
+        $query = is_string($q) ? trim($q) : '';
+
+        $results = [];
+
+        foreach ($this->registry->sources() as $source) {
+            foreach ($source->search($query) as $result) {
+                if ($result instanceof SearchResult) {
+                    $results[] = $result;
+                }
+            }
+        }
+
+        usort($results, static fn (SearchResult $a, SearchResult $b): int => $b->score <=> $a->score);
+
+        return SearchResultResource::collection(ApiPagination::fromArray($results));
+    }
+}

--- a/packages/liberu-cms/cms-search/src/Http/Requests/SearchRequest.php
+++ b/packages/liberu-cms/cms-search/src/Http/Requests/SearchRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the Delivery API search query. A query shorter than the configured
+ * minimum is rejected with a 422.
+ */
+final class SearchRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        $min = config('cms-search.min_query_length', 2);
+        $min = is_numeric($min) ? (int) $min : 2;
+
+        return [
+            'q' => ['required', 'string', 'min:'.$min],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'q.required' => 'A search query (q) is required.',
+            'q.min' => 'The search query is too short.',
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-search/src/Http/Resources/SearchResultResource.php
+++ b/packages/liberu-cms/cms-search/src/Http/Resources/SearchResultResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\Cms\Contracts\Search\SearchResult;
+
+/**
+ * The Delivery API wire shape for a search hit. `type` + `slug` let the consumer
+ * build its own link to the underlying content.
+ *
+ * @mixin SearchResult
+ */
+final class SearchResultResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'type' => $this->type,
+            'id' => $this->id,
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'score' => $this->score,
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-search/src/SearchRegistry.php
+++ b/packages/liberu-cms/cms-search/src/SearchRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Search;
+
+use Liberu\Cms\Contracts\Search\SearchableSourceInterface;
+use Liberu\Cms\Contracts\Search\SearchRegistryInterface;
+
+/**
+ * In-memory catalogue of module-contributed searchable sources. Mirrors the
+ * admin, API, and sitemap registries.
+ */
+final class SearchRegistry implements SearchRegistryInterface
+{
+    /**
+     * @var array<int, SearchableSourceInterface>
+     */
+    private array $sources = [];
+
+    public function registerSource(SearchableSourceInterface $source): void
+    {
+        $this->sources[] = $source;
+    }
+
+    public function sources(): array
+    {
+        return $this->sources;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
         - packages/liberu-cms/cms-menus/src
         - packages/liberu-cms/cms-pages/src
         - packages/liberu-cms/cms-posts/src
+        - packages/liberu-cms/cms-search/src
         - packages/liberu-cms/cms-seo/src
         - packages/liberu-cms/cms-themes/src
         - packages/liberu-cms/cms-users/src

--- a/tests/Feature/Api/SearchApiTest.php
+++ b/tests/Feature/Api/SearchApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Pages\Models\Page;
+use Liberu\Cms\Posts\Models\Post;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+});
+
+it('rejects an unauthenticated search with 401', function (): void {
+    $this->getJson('/api/v1/search?q=laravel')->assertUnauthorized();
+});
+
+it('rejects a missing or too-short query with 422', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    $this->getJson('/api/v1/search')->assertStatus(422);
+    $this->getJson('/api/v1/search?q=a')->assertStatus(422);
+});
+
+it('returns published matches across content types for the tenant', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Laravel Guide', 'slug' => 'laravel-guide', 'content' => 'x']);
+    Post::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Laravel Tips', 'slug' => 'laravel-tips', 'content' => 'x']);
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Cooking', 'slug' => 'cooking', 'content' => 'food']);
+
+    $response = $this->getJson('/api/v1/search?q=Laravel');
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('meta.total', 2);
+
+    $types = collect($response->json('data'))->pluck('type')->sort()->values()->all();
+    expect($types)->toBe(['page', 'post']);
+});
+
+it('excludes draft content from search', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    Page::factory()->create(['team_id' => $this->teamA->id, 'title' => 'Laravel Draft', 'slug' => 'laravel-draft']);
+
+    $this->getJson('/api/v1/search?q=Laravel')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('does not leak another tenant\'s content in search', function (): void {
+    Page::factory()->published()->create(['team_id' => $this->teamB->id, 'title' => 'Laravel Secret', 'slug' => 'laravel-secret']);
+
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    $this->getJson('/api/v1/search?q=Laravel')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('ranks a title match above a body-only match', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Other', 'slug' => 'body-match', 'content' => 'all about Laravel', 'excerpt' => 'none']);
+    Page::factory()->published()->create(['team_id' => $this->teamA->id, 'title' => 'Laravel Handbook', 'slug' => 'title-match', 'content' => 'x', 'excerpt' => 'none']);
+
+    $response = $this->getJson('/api/v1/search?q=Laravel');
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('data.0.slug', 'title-match')
+        ->assertJsonPath('data.1.slug', 'body-match');
+});
+
+it('paginates search results with per_page', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    Page::factory()->published()->count(9)->create(['team_id' => $this->teamA->id, 'title' => fn () => 'Laravel '.fake()->unique()->word()]);
+
+    $this->getJson('/api/v1/search?q=Laravel&per_page=4')
+        ->assertOk()
+        ->assertJsonCount(4, 'data')
+        ->assertJsonPath('meta.per_page', 4)
+        ->assertJsonPath('meta.total', 9);
+});


### PR DESCRIPTION
Add full-text search over published content, exposed on the Delivery API.

New cms-search package registers a GET /api/v1/search endpoint into the API resource registry, so it inherits the Delivery API's Sanctum auth, tenant context, and rate limiting. Results are scoped to the token's Team and to published content, merged across content types, ranked by score (title match above body-only match), and paginated with the standard envelope. A missing or too-short q returns 422 (min length from config).

Sources are aggregated through a new SearchRegistry: each content module registers a SearchableSourceInterface (same pattern as the admin/API/sitemap registries), so cms-search never imports a module. Sources register in boot() because the registry binds in the later-loading cms-search provider. cms-pages, cms-posts, and cms-content-types each add a source backed by a new repository search() method (LIKE over title/body, reusing each repo's published filter; LIKE wildcards escaped). Ranking/limit live in a shared SearchScoring helper (cms-core). v1 uses a database driver; the source seam allows swapping in Scout later.

Tests: tests/Feature/Api/SearchApiTest covers auth (401), validation (422), cross-type results, draft exclusion, tenant isolation, title-over-body ranking, and pagination. Pint, PHPStan max, and the full Pest suite (450) are green.