### PR TITLE
Phase 5 (4/n): cms-api writes — authenticated create/update/delete

### DIFF
--- a/packages/liberu-cms/cms-api/README.md
+++ b/packages/liberu-cms/cms-api/README.md
@@ -22,10 +22,18 @@ Team's published content. A missing or invalid token returns `401`.
 ### Issuing a token
 
 ```
-php artisan cms-api:issue-token {team} [--name=delivery]
+php artisan cms-api:issue-token {team} [--name=delivery] [--write]
 ```
 
 Prints the plaintext token once. Store it immediately; it is not recoverable.
+Tokens are read-only (`content:read`) by default; pass `--write` to also grant
+`content:write` for the create/update/delete endpoints.
+
+### Abilities
+
+- **Read** endpoints require only a valid token.
+- **Write** endpoints (`POST`/`PUT`/`DELETE`) require the `content:write`
+  ability; a read-only token receives `403`.
 
 ### Revoking a token
 
@@ -65,6 +73,13 @@ Control the page size with `?per_page=` up to the cap in
 | GET | `/api/v1/menus/{location}` | A menu by location, with its ordered item tree |
 | GET | `/api/v1/content/{type}` | Published entries of a content type |
 | GET | `/api/v1/content/{type}/{slug}` | A published content entry by slug |
+| POST | `/api/v1/pages` · `/posts` · `/content-entries` | Create content (requires `content:write`) |
+| PUT | `/api/v1/pages/{id}` · `/posts/{id}` · `/content-entries/{id}` | Update content (requires `content:write`) |
+| DELETE | `/api/v1/pages/{id}` · `/posts/{id}` · `/content-entries/{id}` | Delete content (requires `content:write`) |
+
+Writes are tenant-stamped on create, tenant-scoped on update/delete (a
+cross-tenant id is `404`), and a `status` change is applied through the
+editorial workflow — an illegal transition returns `422`.
 
 Exact routes depend on which content modules are installed; a headless
 deployment can ship a subset of modules and the API exposes only their

--- a/packages/liberu-cms/cms-api/src/CmsApiServiceProvider.php
+++ b/packages/liberu-cms/cms-api/src/CmsApiServiceProvider.php
@@ -10,6 +10,8 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\Contracts\HasApiTokens;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 use Laravel\Sanctum\PersonalAccessToken;
 use Liberu\Cms\Api\Console\IssueTokenCommand;
 use Liberu\Cms\Api\Http\Middleware\ForceJsonResponse;
@@ -46,6 +48,10 @@ final class CmsApiServiceProvider extends ModuleServiceProvider
 
     protected function bootModule(): void
     {
+        $router = $this->app->make('router');
+        $router->aliasMiddleware('abilities', CheckAbilities::class);
+        $router->aliasMiddleware('ability', CheckForAnyAbility::class);
+
         $this->configureRateLimiting();
         $this->registerRoutes();
 
@@ -108,6 +114,7 @@ final class CmsApiServiceProvider extends ModuleServiceProvider
                 foreach ($endpoints as $group) {
                     foreach ($group as $endpoint) {
                         Route::match([$endpoint->method], $endpoint->uri, [$endpoint->controller, $endpoint->action])
+                            ->middleware($endpoint->middleware)
                             ->name('cms-api.'.$endpoint->name);
                     }
                 }

--- a/packages/liberu-cms/cms-api/src/Console/IssueTokenCommand.php
+++ b/packages/liberu-cms/cms-api/src/Console/IssueTokenCommand.php
@@ -16,9 +16,10 @@ use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
 final class IssueTokenCommand extends Command
 {
     protected $signature = 'cms-api:issue-token {team : The Team (tenant) id to issue a Delivery token for}
-        {--name=delivery : A human-readable label for the token}';
+        {--name=delivery : A human-readable label for the token}
+        {--write : Also grant write access (content:write) in addition to read}';
 
-    protected $description = 'Issue a read-only Delivery API token for a Team.';
+    protected $description = 'Issue a Delivery API token for a Team (read-only by default).';
 
     public function handle(TenantModelResolverInterface $resolver): int
     {
@@ -39,7 +40,13 @@ final class IssueTokenCommand extends Command
             return self::FAILURE;
         }
 
-        $token = $team->createToken((string) $this->option('name'), ['content:read']);
+        $abilities = ['content:read'];
+
+        if ($this->option('write')) {
+            $abilities[] = 'content:write';
+        }
+
+        $token = $team->createToken((string) $this->option('name'), $abilities);
 
         $this->info('Delivery token issued. Store it now — it will not be shown again:');
         $this->line($token->plainTextToken);

--- a/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
+++ b/packages/liberu-cms/cms-content-types/src/ContentTypesServiceProvider.php
@@ -8,6 +8,7 @@ use Liberu\Cms\ContentTypes\Contracts\ContentEntryRepositoryInterface;
 use Liberu\Cms\ContentTypes\Filament\ContentEntryResource;
 use Liberu\Cms\ContentTypes\Filament\ContentTypeResource;
 use Liberu\Cms\ContentTypes\Http\Controllers\ContentEntryApiController;
+use Liberu\Cms\ContentTypes\Http\Controllers\ContentEntryWriteController;
 use Liberu\Cms\ContentTypes\Models\ContentEntry;
 use Liberu\Cms\ContentTypes\Repositories\ContentEntryRepository;
 use Liberu\Cms\ContentTypes\Schema\SchemaValidator;
@@ -43,6 +44,9 @@ final class ContentTypesServiceProvider extends ModuleServiceProvider
             $registry = $this->app->make(ApiResourceRegistryInterface::class);
             $registry->registerEndpoint('content-types', new ApiEndpoint('content/{type}', ContentEntryApiController::class, 'index', 'content.index'));
             $registry->registerEndpoint('content-types', new ApiEndpoint('content/{type}/{slug}', ContentEntryApiController::class, 'show', 'content.show'));
+            $registry->registerEndpoint('content-types', new ApiEndpoint('content-entries', ContentEntryWriteController::class, 'store', 'content-entries.store', 'POST', ['abilities:content:write']));
+            $registry->registerEndpoint('content-types', new ApiEndpoint('content-entries/{id}', ContentEntryWriteController::class, 'update', 'content-entries.update', 'PUT', ['abilities:content:write']));
+            $registry->registerEndpoint('content-types', new ApiEndpoint('content-entries/{id}', ContentEntryWriteController::class, 'destroy', 'content-entries.destroy', 'DELETE', ['abilities:content:write']));
         }
     }
 

--- a/packages/liberu-cms/cms-content-types/src/Http/Controllers/ContentEntryWriteController.php
+++ b/packages/liberu-cms/cms-content-types/src/Http/Controllers/ContentEntryWriteController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Liberu\Cms\ContentTypes\Contracts\ContentEntryRepositoryInterface;
+use Liberu\Cms\ContentTypes\Http\Requests\StoreContentEntryRequest;
+use Liberu\Cms\ContentTypes\Http\Requests\UpdateContentEntryRequest;
+use Liberu\Cms\ContentTypes\Http\Resources\ContentEntryResource;
+use Liberu\Cms\ContentTypes\Models\ContentEntry;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+use Liberu\Cms\Core\Http\Concerns\WritesWorkflowContent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Handles Content-Entry writes on the Delivery API. Requires the `content:write`
+ * ability; the tenant is stamped on create and reads are tenant-scoped.
+ */
+final readonly class ContentEntryWriteController
+{
+    use WritesWorkflowContent;
+
+    public function __construct(private ContentEntryRepositoryInterface $entries) {}
+
+    public function store(StoreContentEntryRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+
+        $entry = ContentEntry::create($data + ['status' => WorkflowState::Draft->value]);
+
+        if ($status !== null && $this->shouldTransition($entry->workflowState(), $status)) {
+            $entry->transitionTo($status);
+        }
+
+        return ContentEntryResource::make($entry->refresh()->load('type'))->response()->setStatusCode(201);
+    }
+
+    public function update(UpdateContentEntryRequest $request, int $id): ContentEntryResource
+    {
+        $entry = $this->entries->find($id);
+
+        if (! $entry instanceof ContentEntry) {
+            throw new NotFoundHttpException;
+        }
+
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+
+        if ($data !== []) {
+            $entry->update($data);
+        }
+
+        if ($status !== null && $this->shouldTransition($entry->workflowState(), $status)) {
+            $entry->transitionTo($status);
+        }
+
+        return ContentEntryResource::make($entry->refresh()->load('type'));
+    }
+
+    public function destroy(int $id): Response
+    {
+        $entry = $this->entries->find($id);
+
+        if (! $entry instanceof ContentEntry) {
+            throw new NotFoundHttpException;
+        }
+
+        $entry->delete();
+
+        return response()->noContent();
+    }
+}

--- a/packages/liberu-cms/cms-content-types/src/Http/Requests/StoreContentEntryRequest.php
+++ b/packages/liberu-cms/cms-content-types/src/Http/Requests/StoreContentEntryRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a Content-Entry create request on the Delivery API. The entry's
+ * field `data` is stored as-is; deep validation against the content type's
+ * schema is a later increment.
+ */
+final class StoreContentEntryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'content_type_id' => ['required', 'integer', 'exists:cms_content_types,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'data' => ['sometimes', 'nullable', 'array'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-content-types/src/Http/Requests/UpdateContentEntryRequest.php
+++ b/packages/liberu-cms/cms-content-types/src/Http/Requests/UpdateContentEntryRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\ContentTypes\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a partial Content-Entry update on the Delivery API.
+ */
+final class UpdateContentEntryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'content_type_id' => ['sometimes', 'integer', 'exists:cms_content_types,id'],
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'required', 'string', 'max:255'],
+            'data' => ['sometimes', 'nullable', 'array'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-contracts/src/Api/ApiEndpoint.php
+++ b/packages/liberu-cms/cms-contracts/src/Api/ApiEndpoint.php
@@ -20,6 +20,7 @@ final class ApiEndpoint
      * @param  string  $action  The controller method to invoke.
      * @param  string  $name  Route-name suffix, e.g. "pages.index".
      * @param  string  $method  The HTTP verb.
+     * @param  array<int, string>  $middleware  Extra middleware applied on top of the API group (e.g. an ability check).
      */
     public function __construct(
         public string $uri,
@@ -27,5 +28,6 @@ final class ApiEndpoint
         public string $action,
         public string $name,
         public string $method = 'GET',
+        public array $middleware = [],
     ) {}
 }

--- a/packages/liberu-cms/cms-core/src/Http/Concerns/WritesWorkflowContent.php
+++ b/packages/liberu-cms/cms-core/src/Http/Concerns/WritesWorkflowContent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Core\Http\Concerns;
+
+use Liberu\Cms\Contracts\Content\WorkflowInterface;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Shared status handling for Delivery API write controllers. A `status` field is
+ * never written directly: it is pulled out of the payload and applied through
+ * the editorial workflow, and an illegal transition is rejected with a 422.
+ * Keeps the write controllers consistent without each re-implementing the rule.
+ */
+trait WritesWorkflowContent
+{
+    /**
+     * Remove and resolve the requested workflow status from the payload.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function pullStatus(array &$data): ?WorkflowState
+    {
+        $value = $data['status'] ?? null;
+        unset($data['status']);
+
+        return is_string($value) ? WorkflowState::from($value) : null;
+    }
+
+    /**
+     * Whether a transition to `$to` should run. Aborts with 422 when the
+     * transition is not allowed; returns false when there is nothing to do.
+     */
+    protected function shouldTransition(WorkflowState $from, ?WorkflowState $to): bool
+    {
+        if ($to === null || $to === $from) {
+            return false;
+        }
+
+        if (! app(WorkflowInterface::class)->canTransition($from, $to)) {
+            abort(422, 'Illegal status transition.');
+        }
+
+        return true;
+    }
+}

--- a/packages/liberu-cms/cms-core/src/Tenant/HasTenant.php
+++ b/packages/liberu-cms/cms-core/src/Tenant/HasTenant.php
@@ -6,6 +6,7 @@ namespace Liberu\Cms\Core\Tenant;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Liberu\Cms\Contracts\Tenancy\TenantContextInterface;
 use Liberu\Cms\Contracts\Tenancy\TenantModelResolverInterface;
 
 /**
@@ -21,6 +22,18 @@ trait HasTenant
     public static function bootHasTenant(): void
     {
         static::addGlobalScope(new TenantScope);
+
+        static::creating(function (Model $model): void {
+            if ($model->getAttribute('team_id') !== null) {
+                return;
+            }
+
+            $tenantId = app(TenantContextInterface::class)->tenantId();
+
+            if ($tenantId !== null) {
+                $model->setAttribute('team_id', $tenantId);
+            }
+        });
     }
 
     /**

--- a/packages/liberu-cms/cms-pages/src/Http/Controllers/PageWriteController.php
+++ b/packages/liberu-cms/cms-pages/src/Http/Controllers/PageWriteController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+use Liberu\Cms\Core\Http\Concerns\WritesWorkflowContent;
+use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
+use Liberu\Cms\Pages\Http\Requests\StorePageRequest;
+use Liberu\Cms\Pages\Http\Requests\UpdatePageRequest;
+use Liberu\Cms\Pages\Http\Resources\PageResource;
+use Liberu\Cms\Pages\Models\Page;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Handles Page writes on the Delivery API. Requires the `content:write` ability.
+ * The tenant is stamped from the request context on create, and reads for update
+ * and delete are tenant-scoped, so a cross-tenant id is simply not found. A
+ * `status` change goes through the editorial workflow.
+ */
+final readonly class PageWriteController
+{
+    use WritesWorkflowContent;
+
+    public function __construct(private PageRepositoryInterface $pages) {}
+
+    public function store(StorePageRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+
+        $page = Page::create($data + ['status' => WorkflowState::Draft->value]);
+
+        if ($status !== null && $this->shouldTransition($page->workflowState(), $status)) {
+            $page->transitionTo($status);
+        }
+
+        return PageResource::make($page->refresh())->response()->setStatusCode(201);
+    }
+
+    public function update(UpdatePageRequest $request, int $id): PageResource
+    {
+        $page = $this->pages->find($id);
+
+        if (! $page instanceof Page) {
+            throw new NotFoundHttpException;
+        }
+
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+
+        if ($data !== []) {
+            $page->update($data);
+        }
+
+        if ($status !== null && $this->shouldTransition($page->workflowState(), $status)) {
+            $page->transitionTo($status);
+        }
+
+        return PageResource::make($page->refresh());
+    }
+
+    public function destroy(int $id): Response
+    {
+        $page = $this->pages->find($id);
+
+        if (! $page instanceof Page) {
+            throw new NotFoundHttpException;
+        }
+
+        $page->delete();
+
+        return response()->noContent();
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/Http/Requests/StorePageRequest.php
+++ b/packages/liberu-cms/cms-pages/src/Http/Requests/StorePageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a Page create request on the Delivery API. Tenant ownership
+ * (team_id) and authorship are never client-supplied — the tenant is stamped
+ * from the request context — so they are absent here by design.
+ */
+final class StorePageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'content' => ['sometimes', 'nullable', 'string'],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'template' => ['sometimes', 'string', 'max:255'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+            'parent_id' => ['sometimes', 'nullable', 'integer'],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/Http/Requests/UpdatePageRequest.php
+++ b/packages/liberu-cms/cms-pages/src/Http/Requests/UpdatePageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Pages\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a partial Page update on the Delivery API: every field is optional,
+ * but any field present must be valid. A `status` change is applied through the
+ * editorial workflow, not written directly.
+ */
+final class UpdatePageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'required', 'string', 'max:255'],
+            'content' => ['sometimes', 'nullable', 'string'],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'template' => ['sometimes', 'string', 'max:255'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+            'parent_id' => ['sometimes', 'nullable', 'integer'],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
+++ b/packages/liberu-cms/cms-pages/src/PagesServiceProvider.php
@@ -16,6 +16,7 @@ use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Pages\Contracts\PageRepositoryInterface;
 use Liberu\Cms\Pages\Filament\PageResource;
 use Liberu\Cms\Pages\Http\Controllers\PageApiController;
+use Liberu\Cms\Pages\Http\Controllers\PageWriteController;
 use Liberu\Cms\Pages\Models\Page;
 use Liberu\Cms\Pages\Repositories\PageRepository;
 use Liberu\Cms\Pages\Search\PageSearchSource;
@@ -42,6 +43,9 @@ final class PagesServiceProvider extends ModuleServiceProvider
             $registry = $this->app->make(ApiResourceRegistryInterface::class);
             $registry->registerEndpoint('pages', new ApiEndpoint('pages', PageApiController::class, 'index', 'pages.index'));
             $registry->registerEndpoint('pages', new ApiEndpoint('pages/{slug}', PageApiController::class, 'show', 'pages.show'));
+            $registry->registerEndpoint('pages', new ApiEndpoint('pages', PageWriteController::class, 'store', 'pages.store', 'POST', ['abilities:content:write']));
+            $registry->registerEndpoint('pages', new ApiEndpoint('pages/{id}', PageWriteController::class, 'update', 'pages.update', 'PUT', ['abilities:content:write']));
+            $registry->registerEndpoint('pages', new ApiEndpoint('pages/{id}', PageWriteController::class, 'destroy', 'pages.destroy', 'DELETE', ['abilities:content:write']));
         }
     }
 

--- a/packages/liberu-cms/cms-posts/src/Http/Controllers/PostWriteController.php
+++ b/packages/liberu-cms/cms-posts/src/Http/Controllers/PostWriteController.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+use Liberu\Cms\Core\Http\Concerns\WritesWorkflowContent;
+use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
+use Liberu\Cms\Posts\Http\Requests\StorePostRequest;
+use Liberu\Cms\Posts\Http\Requests\UpdatePostRequest;
+use Liberu\Cms\Posts\Http\Resources\PostResource;
+use Liberu\Cms\Posts\Models\Category;
+use Liberu\Cms\Posts\Models\Post;
+use Liberu\Cms\Posts\Models\Tag;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Handles Post writes on the Delivery API. Requires the `content:write` ability.
+ * Category and tag ids are synced through tenant-scoped queries, so a foreign
+ * tenant's taxonomy id is silently dropped rather than attached.
+ */
+final readonly class PostWriteController
+{
+    use WritesWorkflowContent;
+
+    public function __construct(private PostRepositoryInterface $posts) {}
+
+    public function store(StorePostRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+        $categories = $this->pullIds($data, 'categories');
+        $tags = $this->pullIds($data, 'tags');
+
+        $post = Post::create($data + ['status' => WorkflowState::Draft->value]);
+
+        $this->syncTaxonomy($post, $categories, $tags);
+
+        if ($status !== null && $this->shouldTransition($post->workflowState(), $status)) {
+            $post->transitionTo($status);
+        }
+
+        return PostResource::make($post->refresh()->load('categories', 'tags'))->response()->setStatusCode(201);
+    }
+
+    public function update(UpdatePostRequest $request, int $id): PostResource
+    {
+        $post = $this->posts->find($id);
+
+        if (! $post instanceof Post) {
+            throw new NotFoundHttpException;
+        }
+
+        $data = $request->validated();
+        $status = $this->pullStatus($data);
+        $categories = $this->pullIds($data, 'categories');
+        $tags = $this->pullIds($data, 'tags');
+
+        if ($data !== []) {
+            $post->update($data);
+        }
+
+        $this->syncTaxonomy($post, $categories, $tags);
+
+        if ($status !== null && $this->shouldTransition($post->workflowState(), $status)) {
+            $post->transitionTo($status);
+        }
+
+        return PostResource::make($post->refresh()->load('categories', 'tags'));
+    }
+
+    public function destroy(int $id): Response
+    {
+        $post = $this->posts->find($id);
+
+        if (! $post instanceof Post) {
+            throw new NotFoundHttpException;
+        }
+
+        $post->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Extract a list of integer ids for a taxonomy key, or null when the key is
+     * absent (meaning "leave the relation untouched").
+     *
+     * @param  array<string, mixed>  $data
+     * @return list<int>|null
+     */
+    private function pullIds(array &$data, string $key): ?array
+    {
+        if (! array_key_exists($key, $data)) {
+            return null;
+        }
+
+        $value = $data[$key];
+        unset($data[$key]);
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $ids = [];
+
+        foreach ($value as $id) {
+            if (is_int($id) || (is_string($id) && is_numeric($id))) {
+                $ids[] = (int) $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param  list<int>|null  $categoryIds
+     * @param  list<int>|null  $tagIds
+     */
+    private function syncTaxonomy(Post $post, ?array $categoryIds, ?array $tagIds): void
+    {
+        if ($categoryIds !== null) {
+            $post->categories()->sync(Category::query()->whereIn('id', $categoryIds)->pluck('id')->all());
+        }
+
+        if ($tagIds !== null) {
+            $post->tags()->sync(Tag::query()->whereIn('id', $tagIds)->pluck('id')->all());
+        }
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/Http/Requests/StorePostRequest.php
+++ b/packages/liberu-cms/cms-posts/src/Http/Requests/StorePostRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a Post create request on the Delivery API. Category and tag ids that
+ * do not belong to the tenant are dropped at sync time, so only shape is checked
+ * here.
+ */
+final class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'content' => ['sometimes', 'nullable', 'string'],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'is_featured' => ['sometimes', 'boolean'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+            'categories' => ['sometimes', 'array'],
+            'categories.*' => ['integer'],
+            'tags' => ['sometimes', 'array'],
+            'tags.*' => ['integer'],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/Http/Requests/UpdatePostRequest.php
+++ b/packages/liberu-cms/cms-posts/src/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Posts\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+
+/**
+ * Validates a partial Post update on the Delivery API.
+ */
+final class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'required', 'string', 'max:255'],
+            'content' => ['sometimes', 'nullable', 'string'],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'is_featured' => ['sometimes', 'boolean'],
+            'status' => ['sometimes', Rule::enum(WorkflowState::class)],
+            'categories' => ['sometimes', 'array'],
+            'categories.*' => ['integer'],
+            'tags' => ['sometimes', 'array'],
+            'tags.*' => ['integer'],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
+++ b/packages/liberu-cms/cms-posts/src/PostsServiceProvider.php
@@ -15,6 +15,7 @@ use Liberu\Cms\Core\Module\ModuleServiceProvider;
 use Liberu\Cms\Posts\Contracts\PostRepositoryInterface;
 use Liberu\Cms\Posts\Filament\PostResource;
 use Liberu\Cms\Posts\Http\Controllers\PostApiController;
+use Liberu\Cms\Posts\Http\Controllers\PostWriteController;
 use Liberu\Cms\Posts\Models\Post;
 use Liberu\Cms\Posts\Repositories\PostRepository;
 use Liberu\Cms\Posts\Search\PostSearchSource;
@@ -40,6 +41,9 @@ final class PostsServiceProvider extends ModuleServiceProvider
             $registry = $this->app->make(ApiResourceRegistryInterface::class);
             $registry->registerEndpoint('posts', new ApiEndpoint('posts', PostApiController::class, 'index', 'posts.index'));
             $registry->registerEndpoint('posts', new ApiEndpoint('posts/{slug}', PostApiController::class, 'show', 'posts.show'));
+            $registry->registerEndpoint('posts', new ApiEndpoint('posts', PostWriteController::class, 'store', 'posts.store', 'POST', ['abilities:content:write']));
+            $registry->registerEndpoint('posts', new ApiEndpoint('posts/{id}', PostWriteController::class, 'update', 'posts.update', 'PUT', ['abilities:content:write']));
+            $registry->registerEndpoint('posts', new ApiEndpoint('posts/{id}', PostWriteController::class, 'destroy', 'posts.destroy', 'DELETE', ['abilities:content:write']));
         }
     }
 

--- a/tests/Feature/Api/ContentEntriesWriteApiTest.php
+++ b/tests/Feature/Api/ContentEntriesWriteApiTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\ContentTypes\Models\ContentEntry;
+use Liberu\Cms\ContentTypes\Models\ContentType;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+    $this->type = ContentType::factory()->create(['key' => 'portfolio']);
+
+    Sanctum::actingAs($this->teamA, ['content:read', 'content:write'], 'sanctum');
+});
+
+it('validates content_type_id on create', function (): void {
+    $this->postJson('/api/v1/content-entries', ['title' => 'No type'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('content_type_id');
+
+    $this->postJson('/api/v1/content-entries', ['title' => 'Bad type', 'content_type_id' => 99999])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('content_type_id');
+});
+
+it('creates a content entry with typed data, stamped with the tenant', function (): void {
+    $response = $this->postJson('/api/v1/content-entries', [
+        'content_type_id' => $this->type->id,
+        'title' => 'My Item',
+        'data' => ['summary' => 'A thing', 'year' => 2026],
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.type', 'portfolio')
+        ->assertJsonPath('data.fields.summary', 'A thing');
+
+    $this->assertDatabaseHas('cms_content_entries', [
+        'slug' => 'my-item',
+        'team_id' => $this->teamA->id,
+    ]);
+});
+
+it('updates and deletes an entry, isolating tenants', function (): void {
+    $entry = ContentEntry::factory()->create(['team_id' => $this->teamA->id, 'content_type_id' => $this->type->id, 'slug' => 'mine']);
+    $other = ContentEntry::factory()->create(['team_id' => $this->teamB->id, 'content_type_id' => $this->type->id, 'slug' => 'theirs']);
+
+    $this->putJson("/api/v1/content-entries/{$entry->id}", ['title' => 'Renamed'])
+        ->assertOk()
+        ->assertJsonPath('data.title', 'Renamed');
+
+    $this->putJson("/api/v1/content-entries/{$other->id}", ['title' => 'Nope'])->assertNotFound();
+
+    $this->deleteJson("/api/v1/content-entries/{$entry->id}")->assertNoContent();
+    $this->assertDatabaseMissing('cms_content_entries', ['id' => $entry->id]);
+});

--- a/tests/Feature/Api/PagesWriteApiTest.php
+++ b/tests/Feature/Api/PagesWriteApiTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Contracts\Content\WorkflowState;
+use Liberu\Cms\Pages\Models\Page;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+});
+
+function asWriter(Team $team): void
+{
+    Sanctum::actingAs($team, ['content:read', 'content:write'], 'sanctum');
+}
+
+function asReader(Team $team): void
+{
+    Sanctum::actingAs($team, ['content:read'], 'sanctum');
+}
+
+it('rejects an unauthenticated write with 401', function (): void {
+    $this->postJson('/api/v1/pages', ['title' => 'X'])->assertUnauthorized();
+});
+
+it('forbids a read-only token from writing with 403', function (): void {
+    asReader($this->teamA);
+
+    $this->postJson('/api/v1/pages', ['title' => 'X'])->assertForbidden();
+});
+
+it('creates a page as a draft, stamped with the token tenant', function (): void {
+    asWriter($this->teamA);
+
+    $response = $this->postJson('/api/v1/pages', [
+        'title' => 'New Page',
+        'content' => 'Body',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.title', 'New Page')
+        ->assertJsonPath('data.slug', 'new-page');
+
+    $this->assertDatabaseHas('cms_pages', [
+        'slug' => 'new-page',
+        'team_id' => $this->teamA->id,
+        'status' => WorkflowState::Draft->value,
+    ]);
+});
+
+it('creates a page as published via the workflow', function (): void {
+    asWriter($this->teamA);
+
+    $response = $this->postJson('/api/v1/pages', [
+        'title' => 'Live Page',
+        'status' => 'published',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.published_at', fn ($value) => $value !== null);
+
+    $this->assertDatabaseHas('cms_pages', ['slug' => 'live-page', 'status' => WorkflowState::Published->value]);
+});
+
+it('validates the create payload', function (): void {
+    asWriter($this->teamA);
+
+    $this->postJson('/api/v1/pages', ['content' => 'no title'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('title');
+});
+
+it('updates a page', function (): void {
+    asWriter($this->teamA);
+    $page = Page::factory()->create(['team_id' => $this->teamA->id, 'title' => 'Old', 'slug' => 'old']);
+
+    $this->putJson("/api/v1/pages/{$page->id}", ['title' => 'Updated'])
+        ->assertOk()
+        ->assertJsonPath('data.title', 'Updated');
+
+    expect($page->refresh()->title)->toBe('Updated');
+});
+
+it('rejects an illegal status transition with 422', function (): void {
+    asWriter($this->teamA);
+    $page = Page::factory()->published()->create(['team_id' => $this->teamA->id, 'slug' => 'pub']);
+
+    // Published -> Review is not an allowed transition.
+    $this->putJson("/api/v1/pages/{$page->id}", ['status' => 'review'])
+        ->assertStatus(422);
+});
+
+it('does not update or delete another tenant\'s page (404)', function (): void {
+    asWriter($this->teamA);
+    $other = Page::factory()->create(['team_id' => $this->teamB->id, 'slug' => 'theirs']);
+
+    $this->putJson("/api/v1/pages/{$other->id}", ['title' => 'Hacked'])->assertNotFound();
+    $this->deleteJson("/api/v1/pages/{$other->id}")->assertNotFound();
+
+    expect($other->refresh()->title)->not->toBe('Hacked');
+});
+
+it('deletes a page', function (): void {
+    asWriter($this->teamA);
+    $page = Page::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'bye']);
+
+    $this->deleteJson("/api/v1/pages/{$page->id}")->assertNoContent();
+
+    $this->assertDatabaseMissing('cms_pages', ['id' => $page->id]);
+});

--- a/tests/Feature/Api/PostsWriteApiTest.php
+++ b/tests/Feature/Api/PostsWriteApiTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Cms\Posts\Models\Category;
+use Liberu\Cms\Posts\Models\Post;
+use Liberu\Cms\Posts\Models\Tag;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->teamA = Team::factory()->create();
+    $this->teamB = Team::factory()->create();
+});
+
+it('forbids a read-only token from creating a post', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read'], 'sanctum');
+
+    $this->postJson('/api/v1/posts', ['title' => 'X'])->assertForbidden();
+});
+
+it('creates a post and syncs only the tenant\'s taxonomy', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read', 'content:write'], 'sanctum');
+
+    $mine = Category::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'mine']);
+    $theirs = Category::factory()->create(['team_id' => $this->teamB->id, 'slug' => 'theirs']);
+    $tag = Tag::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'php']);
+
+    $response = $this->postJson('/api/v1/posts', [
+        'title' => 'Hello',
+        'categories' => [$mine->id, $theirs->id],
+        'tags' => [$tag->id],
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonCount(1, 'data.categories')
+        ->assertJsonPath('data.categories.0.slug', 'mine')
+        ->assertJsonPath('data.tags.0.slug', 'php');
+
+    $post = Post::query()->firstOrFail();
+    expect($post->team_id)->toBe($this->teamA->id)
+        ->and($post->categories()->pluck('cms_categories.id')->all())->toBe([$mine->id]);
+});
+
+it('updates and deletes a post, isolating tenants', function (): void {
+    Sanctum::actingAs($this->teamA, ['content:read', 'content:write'], 'sanctum');
+
+    $post = Post::factory()->create(['team_id' => $this->teamA->id, 'slug' => 'mine']);
+    $other = Post::factory()->create(['team_id' => $this->teamB->id, 'slug' => 'theirs']);
+
+    $this->putJson("/api/v1/posts/{$post->id}", ['title' => 'Renamed'])
+        ->assertOk()
+        ->assertJsonPath('data.title', 'Renamed');
+
+    $this->putJson("/api/v1/posts/{$other->id}", ['title' => 'Nope'])->assertNotFound();
+
+    $this->deleteJson("/api/v1/posts/{$post->id}")->assertNoContent();
+    $this->assertDatabaseMissing('cms_posts', ['id' => $post->id]);
+});


### PR DESCRIPTION
Extend the Delivery API from read-only to authenticated writes for Pages, Posts, and Content-Entries.

Write endpoints (POST/PUT/DELETE) are gated by a new content:write token ability: ApiEndpoint now carries optional per-route middleware, cms-api registers Sanctum's ability aliases and applies abilities:content:write to writes, and cms-api:issue-token gains a --write flag. A read-only token gets 403; an unauthenticated request 401.

Tenancy on write: a HasTenant creating hook stamps team_id from the request tenant context (no-op outside an API request, so the panel/web/CLI are unchanged); update and delete resolve the model through the tenant-scoped repository, so a cross-tenant id is 404. Validation uses Form Requests per resource. A status change is never written directly — it goes through the editorial workflow via a shared WritesWorkflowContent controller trait (cms-core), and an illegal transition returns 422. Posts sync category/tag ids through tenant-scoped queries, dropping any that belong to another tenant.

Tests: PagesWriteApiTest, PostsWriteApiTest, ContentEntriesWriteApiTest cover ability gating (401/403), tenant stamping, validation (422), workflow transitions incl. illegal (422), taxonomy tenant-safety, tenant isolation (404), and delete (204). Pint, PHPStan max, and the full Pest suite (465) are green.