### PR TITLE
Phase 5 (5/n): cms-forms — public forms with spam-protected submissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "liberu-cms/cms-content": "*",
         "liberu-cms/cms-content-types": "*",
         "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-forms": "*",
         "liberu-cms/cms-core": "*",
         "liberu-cms/cms-hello": "*",
         "liberu-cms/cms-media": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbeda18e9c99ada58a062cae4c16dbc8",
+    "content-hash": "42571ba05b40c757ad691c2dc973c76f",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5917,6 +5917,53 @@
                 "MIT"
             ],
             "description": "The Liberu CMS kernel: module registry, lifecycle manager, event bus, base module classes, and the module generator.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
+        {
+            "name": "liberu-cms/cms-forms",
+            "version": "0.1.0",
+            "dist": {
+                "type": "path",
+                "url": "packages/liberu-cms/cms-forms",
+                "reference": "3d7c20acb62d99d1e449c8660c2a382d33181e98"
+            },
+            "require": {
+                "illuminate/contracts": "^13.0",
+                "illuminate/database": "^13.0",
+                "illuminate/http": "^13.0",
+                "illuminate/routing": "^13.0",
+                "illuminate/support": "^13.0",
+                "liberu-cms/cms-content": "*",
+                "liberu-cms/cms-contracts": "*",
+                "liberu-cms/cms-core": "*",
+                "php": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Liberu\\Cms\\Forms\\CmsFormsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Liberu\\Cms\\Forms\\": "src/",
+                    "Liberu\\Cms\\Forms\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Cms\\Forms\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Forms module for Liberu CMS: public form definitions and spam-protected submissions that emit a FormSubmitted event.",
             "transport-options": {
                 "symlink": true,
                 "relative": true

--- a/packages/liberu-cms/cms-contracts/src/Events/Form/FormSubmitted.php
+++ b/packages/liberu-cms/cms-contracts/src/Events/Form/FormSubmitted.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Contracts\Events\Form;
+
+use Liberu\Cms\Contracts\Events\CmsEvent;
+
+/**
+ * Emitted when a public form submission is accepted and stored. Notification,
+ * CRM, and automation modules listen for this to react to new submissions.
+ */
+final readonly class FormSubmitted implements CmsEvent
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(
+        public string $formSlug,
+        public int|string $submissionId,
+        public int|string|null $teamId,
+        public array $data,
+    ) {}
+
+    public function name(): string
+    {
+        return 'forms.submitted';
+    }
+}

--- a/packages/liberu-cms/cms-forms/README.md
+++ b/packages/liberu-cms/cms-forms/README.md
@@ -1,0 +1,49 @@
+# CMS Forms
+
+Public form definitions and spam-protected submissions. Each accepted submission
+is stored and announced on the event bus as `FormSubmitted`, so a notification
+or automation module can react without this module knowing about it.
+
+## Submitting
+
+```
+POST /forms/{slug}
+```
+
+- Public (no authentication) — a visitor's browser posts directly. Rate-limited
+  per IP (`config('cms-forms.rate_limit')`).
+- The payload is validated against the form's field schema; a required field
+  missing or a value failing its type rule returns `422`.
+- A filled honeypot field (`config('cms-forms.honeypot')`, default `_hp`) marks
+  the request as a bot: it is accepted with `201` but not stored.
+- On success the submission is stored, stamped with the form's tenant, and a
+  `Liberu\Cms\Contracts\Events\Form\FormSubmitted` event is dispatched.
+
+## Defining a form
+
+Forms are created programmatically (a Filament admin surface is a follow-up):
+
+```php
+Form::create([
+    'name' => 'Contact',
+    'fields' => [
+        ['name' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true],
+        ['name' => 'message', 'label' => 'Message', 'type' => 'textarea', 'required' => true],
+    ],
+]);
+```
+
+Field `type` is one of: `text`, `email`, `textarea`, `number`, `checkbox`.
+
+## Reacting to submissions
+
+```php
+$events->listen(FormSubmitted::class, function (FormSubmitted $event): void {
+    // notify, forward to a CRM, ...
+});
+```
+
+## Config
+
+Publish with `php artisan vendor:publish --tag=cms-forms-config`: `honeypot`,
+`rate_limit`, `success_message`.

--- a/packages/liberu-cms/cms-forms/composer.json
+++ b/packages/liberu-cms/cms-forms/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "liberu-cms/cms-forms",
+    "description": "Forms module for Liberu CMS: public form definitions and spam-protected submissions that emit a FormSubmitted event.",
+    "type": "library",
+    "license": "MIT",
+    "version": "0.1.0",
+    "require": {
+        "php": "^8.5",
+        "liberu-cms/cms-contracts": "*",
+        "liberu-cms/cms-content": "*",
+        "liberu-cms/cms-core": "*",
+        "illuminate/contracts": "^13.0",
+        "illuminate/database": "^13.0",
+        "illuminate/http": "^13.0",
+        "illuminate/routing": "^13.0",
+        "illuminate/support": "^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Liberu\\Cms\\Forms\\": "src/",
+            "Liberu\\Cms\\Forms\\Database\\Factories\\": "database/factories/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Liberu\\Cms\\Forms\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Liberu\\Cms\\Forms\\CmsFormsServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/liberu-cms/cms-forms/config/forms.php
+++ b/packages/liberu-cms/cms-forms/config/forms.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Honeypot field
+    |--------------------------------------------------------------------------
+    |
+    | The name of a hidden field that real users leave empty. A submission that
+    | fills it is treated as a bot and silently discarded.
+    |
+    */
+
+    'honeypot' => env('FORMS_HONEYPOT_FIELD', '_hp'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate limit
+    |--------------------------------------------------------------------------
+    |
+    | Submissions per minute allowed per client IP.
+    |
+    */
+
+    'rate_limit' => (int) env('FORMS_RATE_LIMIT', 10),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Success message
+    |--------------------------------------------------------------------------
+    */
+
+    'success_message' => 'Thank you for your submission.',
+
+];

--- a/packages/liberu-cms/cms-forms/database/factories/FormFactory.php
+++ b/packages/liberu-cms/cms-forms/database/factories/FormFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Liberu\Cms\Forms\Models\Form;
+
+/**
+ * @extends Factory<Form>
+ */
+final class FormFactory extends Factory
+{
+    #[\Override]
+    protected $model = Form::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'name' => $name,
+            'slug' => str($name)->slug()->value(),
+            'fields' => [
+                ['name' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true],
+                ['name' => 'message', 'label' => 'Message', 'type' => 'textarea', 'required' => true],
+            ],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-forms/database/factories/FormSubmissionFactory.php
+++ b/packages/liberu-cms/cms-forms/database/factories/FormSubmissionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Liberu\Cms\Forms\Models\Form;
+use Liberu\Cms\Forms\Models\FormSubmission;
+
+/**
+ * @extends Factory<FormSubmission>
+ */
+final class FormSubmissionFactory extends Factory
+{
+    #[\Override]
+    protected $model = FormSubmission::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'form_id' => Form::factory(),
+            'data' => [
+                'email' => $this->faker->safeEmail(),
+                'message' => $this->faker->sentence(),
+            ],
+            'meta' => ['ip' => $this->faker->ipv4()],
+        ];
+    }
+}

--- a/packages/liberu-cms/cms-forms/database/migrations/2026_02_01_000000_create_cms_forms_table.php
+++ b/packages/liberu-cms/cms-forms/database/migrations/2026_02_01_000000_create_cms_forms_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cms_forms', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->json('fields')->nullable();
+            $table->unsignedBigInteger('team_id')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_forms');
+    }
+};

--- a/packages/liberu-cms/cms-forms/database/migrations/2026_02_01_000001_create_cms_form_submissions_table.php
+++ b/packages/liberu-cms/cms-forms/database/migrations/2026_02_01_000001_create_cms_form_submissions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cms_form_submissions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('form_id')->constrained('cms_forms')->cascadeOnDelete();
+            $table->json('data')->nullable();
+            $table->json('meta')->nullable();
+            $table->unsignedBigInteger('team_id')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_form_submissions');
+    }
+};

--- a/packages/liberu-cms/cms-forms/routes/web.php
+++ b/packages/liberu-cms/cms-forms/routes/web.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Liberu\Cms\Forms\Http\Controllers\FormSubmissionController;
+
+Route::post('/forms/{slug}', FormSubmissionController::class)
+    ->middleware('throttle:cms-forms')
+    ->name('cms-forms.submit');

--- a/packages/liberu-cms/cms-forms/src/CmsFormsModule.php
+++ b/packages/liberu-cms/cms-forms/src/CmsFormsModule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms;
+
+use Liberu\Cms\Core\Module\AbstractModule;
+
+/**
+ * Forms. Public form definitions and spam-protected submissions, emitting a
+ * FormSubmitted event other modules can react to. Consumes only contracts, the
+ * core module system, and the content library (for slugs).
+ */
+final class CmsFormsModule extends AbstractModule
+{
+    public function key(): string
+    {
+        return 'forms';
+    }
+
+    public function name(): string
+    {
+        return 'Forms';
+    }
+
+    public function version(): string
+    {
+        return '0.1.0';
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/CmsFormsServiceProvider.php
+++ b/packages/liberu-cms/cms-forms/src/CmsFormsServiceProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Liberu\Cms\Contracts\Module\ModuleInterface;
+use Liberu\Cms\Core\Module\ModuleServiceProvider;
+use Liberu\Cms\Forms\Support\SubmissionValidator;
+
+/**
+ * Wires the Forms module: the submission validator, the per-IP submit throttle,
+ * the public submit route, and the migrations.
+ */
+final class CmsFormsServiceProvider extends ModuleServiceProvider
+{
+    private const string RATE_LIMITER = 'cms-forms';
+
+    public function module(): ModuleInterface
+    {
+        return new CmsFormsModule;
+    }
+
+    protected function registerModule(): void
+    {
+        $this->mergeModuleConfig(__DIR__.'/../config/forms.php', 'cms-forms');
+
+        $this->app->singleton(SubmissionValidator::class);
+    }
+
+    protected function bootModule(): void
+    {
+        $this->loadModuleMigrations(__DIR__.'/../database/migrations');
+        $this->configureRateLimiting();
+        $this->loadModuleRoutesFrom(__DIR__.'/../routes/web.php');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/forms.php' => $this->app->configPath('cms-forms.php'),
+            ], 'cms-forms-config');
+        }
+    }
+
+    private function configureRateLimiting(): void
+    {
+        RateLimiter::for(self::RATE_LIMITER, function (Request $request): Limit {
+            $configured = config('cms-forms.rate_limit', 10);
+            $perMinute = is_numeric($configured) ? (int) $configured : 10;
+
+            return Limit::perMinute($perMinute)->by(self::RATE_LIMITER.':'.($request->ip() ?? 'unknown'));
+        });
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Fields/FormField.php
+++ b/packages/liberu-cms/cms-forms/src/Fields/FormField.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Fields;
+
+/**
+ * A single field in a form's schema: the submitted key, its label, input type,
+ * and whether it is required.
+ */
+final readonly class FormField
+{
+    public function __construct(
+        public string $name,
+        public string $label,
+        public FormFieldType $type,
+        public bool $required = false,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $name = $data['name'] ?? '';
+        $label = $data['label'] ?? '';
+        $type = $data['type'] ?? 'text';
+
+        return new self(
+            name: is_string($name) ? $name : '',
+            label: is_string($label) ? $label : '',
+            type: (is_string($type) ? FormFieldType::tryFrom($type) : null) ?? FormFieldType::Text,
+            required: (bool) ($data['required'] ?? false),
+        );
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Fields/FormFieldType.php
+++ b/packages/liberu-cms/cms-forms/src/Fields/FormFieldType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Fields;
+
+/**
+ * The input types a form field may declare. Each maps to a Laravel validation
+ * rule fragment applied to the submitted value.
+ */
+enum FormFieldType: string
+{
+    case Text = 'text';
+    case Email = 'email';
+    case Textarea = 'textarea';
+    case Number = 'number';
+    case Checkbox = 'checkbox';
+
+    public function rule(): string
+    {
+        return match ($this) {
+            self::Email => 'email',
+            self::Number => 'numeric',
+            self::Checkbox => 'boolean',
+            self::Text, self::Textarea => 'string',
+        };
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Http/Controllers/FormSubmissionController.php
+++ b/packages/liberu-cms/cms-forms/src/Http/Controllers/FormSubmissionController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Events\Form\FormSubmitted;
+use Liberu\Cms\Forms\Models\Form;
+use Liberu\Cms\Forms\Models\FormSubmission;
+use Liberu\Cms\Forms\Support\SubmissionValidator;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Accepts a public form submission: validates it against the form's schema,
+ * stores it (stamped with the form's tenant), and announces FormSubmitted on the
+ * event bus. A filled honeypot field is treated as a bot and silently accepted
+ * without storing.
+ */
+final readonly class FormSubmissionController
+{
+    public function __construct(
+        private EventBusInterface $events,
+        private SubmissionValidator $validator,
+    ) {}
+
+    public function __invoke(Request $request, string $slug): JsonResponse
+    {
+        $form = Form::query()->where('slug', $slug)->first();
+
+        if (! $form instanceof Form) {
+            throw new NotFoundHttpException;
+        }
+
+        if ($this->looksAutomated($request)) {
+            return response()->json(['message' => $this->successMessage()], 201);
+        }
+
+        $data = $this->validator->validate($form, $request->all());
+
+        $submission = FormSubmission::create([
+            'form_id' => $form->id,
+            'team_id' => $form->team_id,
+            'data' => $data,
+            'meta' => ['ip' => $request->ip(), 'user_agent' => $request->userAgent()],
+        ]);
+
+        $this->events->dispatch(new FormSubmitted($form->slug, $submission->id, $form->team_id, $data));
+
+        return response()->json(['message' => $this->successMessage()], 201);
+    }
+
+    private function looksAutomated(Request $request): bool
+    {
+        $honeypot = config('cms-forms.honeypot');
+
+        return is_string($honeypot) && filled($request->input($honeypot));
+    }
+
+    private function successMessage(): string
+    {
+        $message = config('cms-forms.success_message');
+
+        return is_string($message) ? $message : 'Thank you for your submission.';
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Models/Form.php
+++ b/packages/liberu-cms/cms-forms/src/Models/Form.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Liberu\Cms\Content\Support\Slugger;
+use Liberu\Cms\Core\Tenant\HasTenant;
+use Liberu\Cms\Forms\Database\Factories\FormFactory;
+use Liberu\Cms\Forms\Fields\FormField;
+
+/**
+ * A public form definition: a named, slugged set of fields that visitors submit.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property array<int, array<string, mixed>>|null $fields
+ * @property int|null $team_id
+ */
+final class Form extends Model
+{
+    /** @use HasFactory<FormFactory> */
+    use HasFactory;
+
+    use HasTenant;
+
+    #[\Override]
+    protected $table = 'cms_forms';
+
+    /**
+     * @var list<string>
+     */
+    #[\Override]
+    protected $fillable = ['name', 'slug', 'fields', 'team_id'];
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return ['fields' => 'array'];
+    }
+
+    #[\Override]
+    protected static function booted(): void
+    {
+        self::saving(function (Form $form): void {
+            if (blank($form->slug) && filled($form->name)) {
+                $form->slug = Slugger::unique($form, $form->name);
+            }
+        });
+    }
+
+    /**
+     * @return HasMany<FormSubmission, $this>
+     */
+    public function submissions(): HasMany
+    {
+        return $this->hasMany(FormSubmission::class);
+    }
+
+    /**
+     * The schema as value objects.
+     *
+     * @return array<int, FormField>
+     */
+    public function fieldDefinitions(): array
+    {
+        return array_map(FormField::fromArray(...), $this->fields ?? []);
+    }
+
+    protected static function newFactory(): FormFactory
+    {
+        return FormFactory::new();
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Models/FormSubmission.php
+++ b/packages/liberu-cms/cms-forms/src/Models/FormSubmission.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Liberu\Cms\Core\Tenant\HasTenant;
+use Liberu\Cms\Forms\Database\Factories\FormSubmissionFactory;
+
+/**
+ * One accepted submission of a form: the validated field values plus request
+ * metadata (ip, user agent).
+ *
+ * @property int $id
+ * @property int $form_id
+ * @property array<string, mixed>|null $data
+ * @property array<string, mixed>|null $meta
+ * @property int|null $team_id
+ */
+final class FormSubmission extends Model
+{
+    /** @use HasFactory<FormSubmissionFactory> */
+    use HasFactory;
+
+    use HasTenant;
+
+    #[\Override]
+    protected $table = 'cms_form_submissions';
+
+    /**
+     * @var list<string>
+     */
+    #[\Override]
+    protected $fillable = ['form_id', 'data', 'meta', 'team_id'];
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return ['data' => 'array', 'meta' => 'array'];
+    }
+
+    /**
+     * @return BelongsTo<Form, $this>
+     */
+    public function form(): BelongsTo
+    {
+        return $this->belongsTo(Form::class);
+    }
+
+    protected static function newFactory(): FormSubmissionFactory
+    {
+        return FormSubmissionFactory::new();
+    }
+}

--- a/packages/liberu-cms/cms-forms/src/Support/SubmissionValidator.php
+++ b/packages/liberu-cms/cms-forms/src/Support/SubmissionValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Cms\Forms\Support;
+
+use Liberu\Cms\Forms\Models\Form;
+
+/**
+ * Validates a raw submission against a form's field schema, returning only the
+ * defined fields' values. Throws a ValidationException (rendered as 422) when a
+ * required field is missing or a value fails its type rule.
+ */
+final class SubmissionValidator
+{
+    /**
+     * @param  array<array-key, mixed>  $input
+     * @return array<string, mixed>
+     */
+    public function validate(Form $form, array $input): array
+    {
+        $rules = [];
+        $attributes = [];
+
+        foreach ($form->fieldDefinitions() as $field) {
+            if ($field->name === '') {
+                continue;
+            }
+
+            $rules[$field->name] = [$field->required ? 'required' : 'nullable', $field->type->rule()];
+            $attributes[$field->name] = $field->label !== '' ? $field->label : $field->name;
+        }
+
+        /** @var array<string, mixed> $validated */
+        $validated = validator($input, $rules, [], $attributes)->validate();
+
+        return $validated;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - packages/liberu-cms/cms-content-types/src
         - packages/liberu-cms/cms-contracts/src
         - packages/liberu-cms/cms-core/src
+        - packages/liberu-cms/cms-forms/src
         - packages/liberu-cms/cms-hello/src
         - packages/liberu-cms/cms-media/src
         - packages/liberu-cms/cms-menus/src

--- a/tests/Feature/Forms/FormSubmissionTest.php
+++ b/tests/Feature/Forms/FormSubmissionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Cms\Contracts\Events\EventBusInterface;
+use Liberu\Cms\Contracts\Events\Form\FormSubmitted;
+use Liberu\Cms\Forms\Models\Form;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->team = Team::factory()->create();
+    $this->form = Form::factory()->create(['slug' => 'contact', 'team_id' => $this->team->id]);
+});
+
+it('accepts a valid submission, stores it, and dispatches the event', function (): void {
+    $received = null;
+    app(EventBusInterface::class)->listen(FormSubmitted::class, function (FormSubmitted $event) use (&$received): void {
+        $received = $event;
+    });
+
+    $response = $this->postJson('/forms/contact', [
+        'email' => 'visitor@example.com',
+        'message' => 'Hello there',
+    ]);
+
+    $response->assertCreated()->assertJsonPath('message', 'Thank you for your submission.');
+
+    $this->assertDatabaseHas('cms_form_submissions', [
+        'form_id' => $this->form->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    expect($received)->toBeInstanceOf(FormSubmitted::class)
+        ->and($received->formSlug)->toBe('contact')
+        ->and($received->data['email'])->toBe('visitor@example.com');
+});
+
+it('rejects a submission missing a required field with 422', function (): void {
+    $this->postJson('/forms/contact', ['email' => 'visitor@example.com'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('message');
+});
+
+it('rejects an invalid field value with 422', function (): void {
+    $this->postJson('/forms/contact', ['email' => 'not-an-email', 'message' => 'hi'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('email');
+});
+
+it('silently drops a submission that trips the honeypot', function (): void {
+    $response = $this->postJson('/forms/contact', [
+        'email' => 'bot@example.com',
+        'message' => 'spam',
+        '_hp' => 'i am a bot',
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseCount('cms_form_submissions', 0);
+});
+
+it('returns 404 for an unknown form', function (): void {
+    $this->postJson('/forms/nope', ['email' => 'a@b.com', 'message' => 'hi'])->assertNotFound();
+});


### PR DESCRIPTION
Add a Forms module: public form definitions and visitor submissions that emit a FormSubmitted event for other modules (e.g. notifications) to react to.

New cms-forms package. A Form has a name, slug, and a JSON field schema (text/email/textarea/number/checkbox). A public, unauthenticated endpoint POST /forms/{slug} validates the submission against the schema (422 on a missing required field or a bad value), stores it stamped with the form's tenant, and dispatches Liberu\Cms\Contracts\Events\Form\FormSubmitted on the event bus. Spam protection: a configurable honeypot field (a filled value is accepted with 201 but not stored) and a per-IP rate limit. Both Form and FormSubmission are tenant-scoped via HasTenant.

The Filament admin surface for managing forms and viewing submissions is a documented follow-up; forms are created programmatically for now.

Tests: tests/Feature/Forms/FormSubmissionTest covers a valid submission (stored + event dispatched), validation (422), honeypot drop, and unknown form (404). Pint, PHPStan max, and the full Pest suite (470) are green.